### PR TITLE
Pass affiliate codes to console

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { ParsedUrlQueryInput } from "querystring";
 
-import { useSetAffiliateCodeToLocalStorage } from "@/hooks/use-affiliate-code-session-storage";
+import { useSetAffiliateCodeToSessionStorage } from "@/hooks/use-affiliate-code-session-storage";
 
 import HomeCommunity from "@/components/home/community";
 import HomeFast from "@/components/home/fast";
@@ -19,7 +19,7 @@ export default function Home({
 }: {
   searchParams: ParsedUrlQueryInput;
 }) {
-  useSetAffiliateCodeToLocalStorage(searchParams);
+  useSetAffiliateCodeToSessionStorage(searchParams);
 
   return (
     <main className="overflow-x-hidden text-center">

--- a/components/master/header.tsx
+++ b/components/master/header.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import cx from "@/utils/cx";
 import { allJobs } from "contentlayer/generated";
 
-import { useGetAffiliateCodeFromLocalStorage } from "@/hooks/use-affiliate-code-session-storage";
+import { useGetAffiliateCodeFromSessionStorage } from "@/hooks/use-affiliate-code-session-storage";
 
 import Button from "@/components/button";
 import Container from "@/components/container";
@@ -20,7 +20,7 @@ export default function Header({
   className,
   ...props
 }: HTMLProps<HTMLHeadElement>) {
-  const { affiliateCode } = useGetAffiliateCodeFromLocalStorage();
+  const { affiliateCode } = useGetAffiliateCodeFromSessionStorage();
 
   return (
     <header className={cx("hidden md:block", className)} {...props}>

--- a/hooks/use-affiliate-code-session-storage.ts
+++ b/hooks/use-affiliate-code-session-storage.ts
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 
 export const AFFILIATE_CODE = "code";
 
-export const useSetAffiliateCodeToLocalStorage = (
+export const useSetAffiliateCodeToSessionStorage = (
   searchParams: ParsedUrlQueryInput,
 ) => {
   useEffect(() => {
@@ -13,7 +13,7 @@ export const useSetAffiliateCodeToLocalStorage = (
   }, [searchParams]);
 };
 
-export const useGetAffiliateCodeFromLocalStorage = () => {
+export const useGetAffiliateCodeFromSessionStorage = () => {
   const [affiliateCode, setAffiliateCode] = useState<string>();
 
   useEffect(() => {


### PR DESCRIPTION
Pass affiliate codes to console via session storage.
Example use case: 
User lands on https://upstash.com/ with ?code=BULLMQ, then we persist that code and pass it query when user clicks on login.