### PR TITLE
Change homepage Qstash example to use v2

### DIFF
--- a/components/home/serverless/http-rest-api.tsx
+++ b/components/home/serverless/http-rest-api.tsx
@@ -128,7 +128,7 @@ const messages = await c.consume({
   topics: ["test.topic"],
   autoOffsetReset: "earliest",
 })`,
-  [Product.QSTASH]: `fetch("https://qstash.upstash.io/v1/publish/https://example.com", {
+  [Product.QSTASH]: `fetch("https://qstash.upstash.io/v2/publish/https://example.com", {
   body: "{ 'hello': 'world' }",
   headers: {
     Authorization: "Bearer XXX",


### PR DESCRIPTION
Small change to make the Homepage example V2 instead of V1

Before:
![image](https://github.com/upstash/upstash-web/assets/24885081/4a334a48-cbdd-42d3-9ccd-394069f1dc89)

After:
![image](https://github.com/upstash/upstash-web/assets/24885081/13d156a9-1cc2-46af-a2f1-1da3e2958b6f)
