### PR TITLE
Add elixir to language labels

### DIFF
--- a/src/app/examples/[slug]/page.tsx
+++ b/src/app/examples/[slug]/page.tsx
@@ -28,6 +28,7 @@ const LanguagesLabel = {
   rs: "Rust",
   rb: "Ruby",
   java: "Java",
+  elixir: "Elixir",
 };
 
 export async function generateStaticParams(): Promise<Props["params"][]> {

--- a/src/components/example/filter.tsx
+++ b/src/components/example/filter.tsx
@@ -23,6 +23,7 @@ const LanguagesLabel = {
   rs: "Rust",
   rb: "Ruby",
   java: "Java",
+  elixir: "Elixir"
 };
 
 export default function ExampleFilter({


### PR DESCRIPTION
We added a tutorial for elixir but didn't update the upstash-web.

Languages filter on [the examples page](https://upstash.com/examples) shows a tick for Elixir but no label:

![image](https://github.com/upstash/upstash-web/assets/57228345/dc86e77d-c104-4c76-a592-6892e82da1bc)

Also, when we navigate to [the Elixir example](https://upstash.com/examples/elixirwithredis), Languages field looks empty:

![image](https://github.com/upstash/upstash-web/assets/57228345/7d5ed1c9-4296-410a-bc28-f851670c0233)

This is because the label is missing. Adding the elixir label with this PR. Tested the changes in my local env.

<details><summary>Post Change</summary>

![image](https://github.com/upstash/upstash-web/assets/57228345/fd856b63-c75a-4022-9c62-333d27fcd68e)

![image](https://github.com/upstash/upstash-web/assets/57228345/93b80e00-45db-4288-9a26-d68a53724363)


</details>