### PR TITLE
Update character size limit of search

### DIFF
--- a/src/components/pricing/search/compare-table.tsx
+++ b/src/components/pricing/search/compare-table.tsx
@@ -219,17 +219,17 @@ export default function CompareTable() {
           {/**/}
           <Col plan={showFree}>
             <CompareValue type="size" suffix="characters">
-              1500
+              4096
             </CompareValue>
           </Col>
           <Col plan={showPayg} feature>
             <CompareValue type="size" suffix="characters">
-              1500
+              4096
             </CompareValue>
           </Col>
           <Col plan={showPro}>
             <CompareValue type="size" suffix="characters">
-              1500
+              4096
             </CompareValue>
           </Col>
         </tr>


### PR DESCRIPTION
We have recently deployed a new version of search with corrected character limit. This change is deployed to all search instances.

This PR updates the corresponding limit in the pricing page.