### PR TITLE
New Pricing For Qstash

### DIFF
--- a/src/components/pricing/qstash/compare-table.tsx
+++ b/src/components/pricing/qstash/compare-table.tsx
@@ -17,8 +17,8 @@ export default function CompareTable() {
 
   const showFree = selectedPlans === PricingPlans.Free;
   const showPayg = selectedPlans === PricingPlans.PayAsYouGo;
-  const showPro1 = selectedPlans === PricingPlans.Pro1M;
-  const showPro10 = selectedPlans === PricingPlans.Pro10M;
+  const showFixed1 = selectedPlans === PricingPlans.Pro1M;
+  const showFixed10 = selectedPlans === PricingPlans.Pro10M;
 
   const onPlanChange = (event: ChangeEvent<HTMLSelectElement>) => {
     const value = event.target.value as PricingPlans;
@@ -76,13 +76,13 @@ export default function CompareTable() {
             Usage Based Pricing
           </Col>
           <Col
-            plan={showPro1}
+            plan={showFixed1}
             className="border-b-2 border-b-bg px-0 py-3 text-xs font-medium uppercase tracking-wider text-text-mute"
           >
             Fixed Pricing
           </Col>
           <Col
-            plan={showPro10}
+            plan={showFixed10}
             className="border-b-2 border-b-bg px-0 py-3 text-xs font-medium uppercase tracking-wider text-text-mute"
           >
             Fixed Pricing
@@ -124,10 +124,10 @@ export default function CompareTable() {
               </h5>
             </div>
           </Col>
-          <Col plan={showPro1} className="border-b border-b-bg bg-bg p-0">
+          <Col plan={showFixed1} className="border-b border-b-bg bg-bg p-0">
             <div className="flex h-24 flex-col items-center justify-center bg-bg-mute">
               <h4 className="hidden text-lg font-semibold text-primary-text md:block">
-                Pro 1M
+                Fixed 1M
               </h4>
 
               <MobileSelectCol
@@ -144,10 +144,10 @@ export default function CompareTable() {
             </div>
           </Col>
 
-          <Col plan={showPro10} className="border-b border-b-bg bg-bg p-0">
+          <Col plan={showFixed10} className="border-b border-b-bg bg-bg p-0">
             <div className="flex h-24 flex-col items-center justify-center bg-bg-mute">
               <h4 className="hidden text-lg font-semibold text-primary-text md:block">
-                Pro 10M
+                Fixed 10M
               </h4>
 
               <MobileSelectCol
@@ -177,35 +177,73 @@ export default function CompareTable() {
           </th>
           {/**/}
           <Col plan={showFree}>
-            <CompareValue type="number">500</CompareValue>
+            <CompareValue type="number">1000</CompareValue>
           </Col>
           <Col plan={showPayg} feature>
-            <CompareValue type="number">500000</CompareValue>
+            <CompareValue>Unlimited</CompareValue>
           </Col>
-          <Col plan={showPro1}>
+          <Col plan={showFixed1}>
             <CompareValue>1M</CompareValue>
           </Col>
-          <Col plan={showPro10}>
+          <Col plan={showFixed10}>
             <CompareValue>10M</CompareValue>
           </Col>
         </tr>
 
+         {/*MAX MONTHLY BANDWIDTH*/}
         <tr>
-          <th className="px-0 py-4 text-left font-normal">
-            Max Requests per Second
+          <th className="px-0 text-left font-normal">
+            <Tooltip content="The max total data size going out from QStash to user endpoints per month.">
+              Max Monthly Bandwidth
+            </Tooltip>
           </th>
           {/**/}
           <Col plan={showFree}>
-            <CompareValue type="number">100</CompareValue>
+            <CompareValue type="size" suffix="GB" className="border-b-0">
+              50
+            </CompareValue>
           </Col>
           <Col plan={showPayg} feature>
-            <CompareValue type="number">100</CompareValue>
+            <CompareValue
+              type="size"
+              suffix="GB"
+              className="border-b-0"
+              after={
+                <Tooltip content="Free up to 50GB per month. Beyond that $0.05 per GB.">
+                  <IconInfoCircle className="ml-1" stroke={1.5} size={24} />
+                </Tooltip>
+              }
+            >
+              50
+            </CompareValue>
           </Col>
-          <Col plan={showPro1}>
-            <CompareValue>500</CompareValue>
+          <Col plan={showFixed1}>
+              <CompareValue
+                type="size"
+                suffix="TB"
+                className="border-b-0"
+                after={
+                  <Tooltip content="Free up to 1TB per month. Beyond that $0.05 per GB.">
+                    <IconInfoCircle className="ml-1" stroke={1.5} size={24} />
+                  </Tooltip>
+                }
+              >
+                1
+              </CompareValue>
           </Col>
-          <Col plan={showPro10}>
-            <CompareValue>1000</CompareValue>
+          <Col plan={showFixed10}>
+              <CompareValue
+                type="size"
+                suffix="TB"
+                className="border-b-0"
+                after={
+                  <Tooltip content="Free up to 5TB per month. Beyond that $0.05 per GB.">
+                    <IconInfoCircle className="ml-1" stroke={1.5} size={24} />
+                  </Tooltip>
+                }
+              >
+                5
+              </CompareValue>
           </Col>
         </tr>
 
@@ -222,12 +260,12 @@ export default function CompareTable() {
               10
             </CompareValue>
           </Col>
-          <Col plan={showPro1}>
+          <Col plan={showFixed1}>
             <CompareValue type="size" suffix="MB">
               50
             </CompareValue>
           </Col>
-          <Col plan={showPro10}>
+          <Col plan={showFixed10}>
             <CompareValue type="size" suffix="MB">
               50
             </CompareValue>
@@ -245,10 +283,10 @@ export default function CompareTable() {
           <Col plan={showPayg} feature>
             <CompareValue>100</CompareValue>
           </Col>
-          <Col plan={showPro1}>
+          <Col plan={showFixed1}>
             <CompareValue>1000</CompareValue>
           </Col>
-          <Col plan={showPro10}>
+          <Col plan={showFixed10}>
             <CompareValue>2000</CompareValue>
           </Col>
         </tr>
@@ -264,10 +302,10 @@ export default function CompareTable() {
           <Col plan={showPayg} feature>
             <CompareValue>100</CompareValue>
           </Col>
-          <Col plan={showPro1}>
+          <Col plan={showFixed1}>
             <CompareValue>1000</CompareValue>
           </Col>
-          <Col plan={showPro10}>
+          <Col plan={showFixed10}>
             <CompareValue>2000</CompareValue>
           </Col>
         </tr>
@@ -281,10 +319,10 @@ export default function CompareTable() {
           <Col plan={showPayg} feature>
             <CompareValue>5</CompareValue>
           </Col>
-          <Col plan={showPro1}>
+          <Col plan={showFixed1}>
             <CompareValue>20</CompareValue>
           </Col>
-          <Col plan={showPro10}>
+          <Col plan={showFixed10}>
             <CompareValue>100</CompareValue>
           </Col>
         </tr>
@@ -298,10 +336,10 @@ export default function CompareTable() {
           <Col plan={showPayg} feature>
             <CompareValue>1 year</CompareValue>
           </Col>
-          <Col plan={showPro1}>
+          <Col plan={showFixed1}>
             <CompareValue>Unlimited</CompareValue>
           </Col>
-          <Col plan={showPro10}>
+          <Col plan={showFixed10}>
             <CompareValue>Unlimited</CompareValue>
           </Col>
         </tr>
@@ -317,10 +355,10 @@ export default function CompareTable() {
           <Col plan={showPayg} feature>
             <CompareValue>2 hours</CompareValue>
           </Col>
-          <Col plan={showPro1}>
+          <Col plan={showFixed1}>
             <CompareValue>6 hours</CompareValue>
           </Col>
-          <Col plan={showPro10}>
+          <Col plan={showFixed10}>
             <CompareValue>12 hours</CompareValue>
           </Col>
         </tr>
@@ -334,10 +372,10 @@ export default function CompareTable() {
           <Col plan={showPayg} feature>
             <CompareValue>7 days</CompareValue>
           </Col>
-          <Col plan={showPro1}>
+          <Col plan={showFixed1}>
             <CompareValue>30 days</CompareValue>
           </Col>
-          <Col plan={showPro10}>
+          <Col plan={showFixed10}>
             <CompareValue>3 months</CompareValue>
           </Col>
         </tr>
@@ -353,10 +391,10 @@ export default function CompareTable() {
           <Col plan={showPayg} feature>
             <CompareValue>7 days</CompareValue>
           </Col>
-          <Col plan={showPro1}>
+          <Col plan={showFixed1}>
             <CompareValue>14 days</CompareValue>
           </Col>
-          <Col plan={showPro10}>
+          <Col plan={showFixed10}>
             <CompareValue>14 days</CompareValue>
           </Col>
         </tr>
@@ -380,7 +418,7 @@ export default function CompareTable() {
               1000
             </CompareValue>
           </Col>
-          <Col plan={showPro1}>
+          <Col plan={showFixed1}>
             <CompareValue
               after={
                 <Tooltip content="Free up to 10K. Beyond that, $0.01 per active schedule.">
@@ -391,7 +429,7 @@ export default function CompareTable() {
               10000
             </CompareValue>
           </Col>
-          <Col plan={showPro10}>
+          <Col plan={showFixed10}>
             <CompareValue
               after={
                 <Tooltip content="Free up to 50K. Beyond that, $0.01 per active schedule.">
@@ -413,10 +451,10 @@ export default function CompareTable() {
           <Col plan={showPayg} feature>
             <CompareValue type="number">100</CompareValue>
           </Col>
-          <Col plan={showPro1}>
+          <Col plan={showFixed1}>
             <CompareValue>1000</CompareValue>
           </Col>
-          <Col plan={showPro10}>
+          <Col plan={showFixed10}>
             <CompareValue>1000</CompareValue>
           </Col>
         </tr>
@@ -432,10 +470,10 @@ export default function CompareTable() {
           <Col plan={showPayg} feature>
             <CompareValue type="number">10</CompareValue>
           </Col>
-          <Col plan={showPro1}>
+          <Col plan={showFixed1}>
             <CompareValue>10</CompareValue>
           </Col>
-          <Col plan={showPro10}>
+          <Col plan={showFixed10}>
             <CompareValue>10</CompareValue>
           </Col>
         </tr>
@@ -451,12 +489,12 @@ export default function CompareTable() {
           <Col plan={showPayg} feature>
             <CompareValue type="boolean" valid={false} />
           </Col>
-          <Col plan={showPro1}>
+          <Col plan={showFixed1}>
             <CompareValue className="">
               <div>99.99%</div>
             </CompareValue>
           </Col>
-          <Col plan={showPro10}>
+          <Col plan={showFixed10}>
             <CompareValue className="">
               <div>99.99%</div>
             </CompareValue>
@@ -476,10 +514,10 @@ export default function CompareTable() {
           <Col plan={showPayg} feature>
             <CompareValue>None</CompareValue>
           </Col>
-          <Col plan={showPro1}>
+          <Col plan={showFixed1}>
             <CompareValue>$180</CompareValue>
           </Col>
-          <Col plan={showPro10}>
+          <Col plan={showFixed10}>
             <CompareValue>$420</CompareValue>
           </Col>
         </tr>
@@ -492,10 +530,10 @@ export default function CompareTable() {
           <Col plan={showPayg} feature>
             <CompareValue>$1 per 100K</CompareValue>
           </Col>
-          <Col plan={showPro1}>
+          <Col plan={showFixed1}>
             <CompareValue>None</CompareValue>
           </Col>
-          <Col plan={showPro10}>
+          <Col plan={showFixed10}>
             <CompareValue>None</CompareValue>
           </Col>
         </tr>
@@ -518,14 +556,14 @@ export default function CompareTable() {
               </a>
             </Button>
           </Col>
-          <Col plan={showPro1} className="py-4">
+          <Col plan={showFixed1} className="py-4">
             <Button asChild variant="primary">
               <a target="_self" href="https://console.upstash.com">
                 Start Now
               </a>
             </Button>
           </Col>
-          <Col plan={showPro10} className="py-4">
+          <Col plan={showFixed10} className="py-4">
             <Button asChild variant="primary">
               <a target="_self" href="https://console.upstash.com/qstash">
                 Start Now
@@ -546,8 +584,8 @@ function MobileSelectCol({ ...props }: React.ComponentProps<"select">) {
     >
       <option value={PricingPlans.Free}>Free</option>
       <option value={PricingPlans.PayAsYouGo}>Pay as you go</option>
-      <option value={PricingPlans.Pro1M}>Pro 1M</option>
-      <option value={PricingPlans.Pro10M}>Pro 10M</option>
+      <option value={PricingPlans.Pro1M}>Fixed 1M</option>
+      <option value={PricingPlans.Pro10M}>Fixed 10M</option>
     </select>
   );
 }

--- a/src/components/pricing/qstash/faq.tsx
+++ b/src/components/pricing/qstash/faq.tsx
@@ -72,7 +72,7 @@ export default function FAQ() {
           What happens when we hit daily max messages limit?
         </AccordionTrigger>
         <AccordionContent>
-          QStash API starts to return exceptions.
+          QStash API starts to return "daily ratelimit YOUR_QUOTA exceeded" with 429 status code.
         </AccordionContent>
       </AccordionItem>
 
@@ -100,6 +100,50 @@ export default function FAQ() {
           </ul>
         </AccordionContent>
       </AccordionItem>
+
+      <AccordionItem value="item-4">
+        <AccordionTrigger>
+          Is there a rate limit ?
+        </AccordionTrigger>
+        <AccordionContent>
+        <ul className="mt-4 list-disc space-y-2 pl-6">
+            <li className="space-y-2">
+              <p>
+                There is no request per second limit for operational API's as listed above:
+              </p>
+              <ul className="mt-4 list-disc space-y-2 pl-6">
+              <li> trigger, publish, enqueue, notify, wait, batch</li>
+              </ul>
+            </li>
+            <li className="space-y-2">
+              <p> Other endpoints (like logs,messages etc) have rps limit. When limit is reached, API returns 
+                "Too Many Requests" with 429 status code.
+              </p>
+              <ul className="mt-4 list-disc space-y-2 pl-6">
+              <li> Free: 100 rps</li>
+              <li> Pay as you go: 100 rps</li>
+              <li> Fixed 1M: 500 rps</li>
+              <li> Fixed 10M: 1000 rps</li>
+              </ul>
+            </li>
+            <li className="space-y-2">
+              <p>
+                We have parallelism limit when calling the user endpoint from QStash. 
+                This limits number of parallel calls that can happen at the same time, other calls are queued to be done 
+                later. The quotas per plan is as follows:
+              </p>
+                <ul className="mt-4 list-disc space-y-2 pl-6">
+                <li> Free: 10</li>
+                <li> Pay as you go: 100</li>
+                <li> Fixed 1M: 200</li>
+                <li> Fixed 10M: 1000 </li>
+              </ul>
+            </li>
+          </ul>
+        </AccordionContent>
+      </AccordionItem>
+
+
     </Accordion.Root>
   );
 }

--- a/src/components/pricing/qstash/pricing-table.tsx
+++ b/src/components/pricing/qstash/pricing-table.tsx
@@ -27,11 +27,7 @@ export default function PricingTable() {
         <div className="w-full px-6 *:border-b *:border-bg-mute">
           <div className="py-3">
             <p className="text-text-mute">Messages per Day</p>
-            <p className="font-semibold">500</p>
-          </div>
-          <div className="py-3">
-            <p className="text-text-mute">Requests per Second</p>
-            <p className="font-semibold">100</p>
+            <p className="font-semibold">1,000</p>
           </div>
         </div>
 
@@ -65,11 +61,7 @@ export default function PricingTable() {
         <div className="w-full px-6 *:border-b *:border-bg-mute">
           <div className="py-3">
             <p className="text-text-mute">Messages per Day</p>
-            <p className="font-semibold">500,000</p>
-          </div>
-          <div className="py-3">
-            <p className="text-text-mute">Requests per Second</p>
-            <p className="font-semibold">100</p>
+            <p className="font-semibold">Unlimited</p>
           </div>
         </div>
 
@@ -82,11 +74,11 @@ export default function PricingTable() {
         </div>
       </div>
 
-      {/* Pro */}
+      {/* Fixed */}
 
       <div className="flex flex-col items-center gap-4 rounded-4xl bg-white p-6 shadow sm:gap-6 sm:p-8 dark:border-bg-mute dark:bg-bg-mute">
         <div className="grow">
-          <h4 className="mb-4 py-1 text-xl font-bold text-primary-text">Pro</h4>
+          <h4 className="mb-4 py-1 text-xl font-bold text-primary-text">Fixed</h4>
 
           <h5 className="flex items-baseline text-2xl font-semibold">
             $180
@@ -108,10 +100,6 @@ export default function PricingTable() {
           <div className="py-3">
             <p className="text-text-mute">Messages per Day</p>
             <p className="font-semibold">Up to 100M</p>
-          </div>
-          <div className="py-3">
-            <p className="text-text-mute">Requests per Second</p>
-            <p className="font-semibold">Up to 1000</p>
           </div>
         </div>
 

--- a/src/components/pricing/workflow/compare-table.tsx
+++ b/src/components/pricing/workflow/compare-table.tsx
@@ -17,8 +17,8 @@ export default function CompareTable() {
 
   const showFree = selectedPlans === PricingPlans.Free;
   const showPayg = selectedPlans === PricingPlans.PayAsYouGo;
-  const showPro1 = selectedPlans === PricingPlans.Pro1M;
-  const showPro10 = selectedPlans === PricingPlans.Pro10M;
+  const showFixed1 = selectedPlans === PricingPlans.Pro1M;
+  const showFixed10 = selectedPlans === PricingPlans.Pro10M;
 
   const onPlanChange = (event: ChangeEvent<HTMLSelectElement>) => {
     const value = event.target.value as PricingPlans;
@@ -76,13 +76,13 @@ export default function CompareTable() {
             Usage Based Pricing
           </Col>
           <Col
-            plan={showPro1}
+            plan={showFixed1}
             className="border-b-2 border-b-bg px-0 py-3 text-xs font-medium uppercase tracking-wider text-text-mute"
           >
             Fixed Pricing
           </Col>
           <Col
-            plan={showPro10}
+            plan={showFixed10}
             className="border-b-2 border-b-bg px-0 py-3 text-xs font-medium uppercase tracking-wider text-text-mute"
           >
             Fixed Pricing
@@ -124,10 +124,10 @@ export default function CompareTable() {
               </h5>
             </div>
           </Col>
-          <Col plan={showPro1} className="border-b border-b-bg bg-bg p-0">
+          <Col plan={showFixed1} className="border-b border-b-bg bg-bg p-0">
             <div className="flex h-24 flex-col items-center justify-center bg-bg-mute">
               <h4 className="hidden text-lg font-semibold text-primary-text md:block">
-                Pro 1M
+                Fixed 1M
               </h4>
 
               <MobileSelectCol
@@ -144,10 +144,10 @@ export default function CompareTable() {
             </div>
           </Col>
 
-          <Col plan={showPro10} className="border-b border-b-bg bg-bg p-0">
+          <Col plan={showFixed10} className="border-b border-b-bg bg-bg p-0">
             <div className="flex h-24 flex-col items-center justify-center bg-bg-mute">
               <h4 className="hidden text-lg font-semibold text-primary-text md:block">
-                Pro 10M
+                Fixed 10M
               </h4>
 
               <MobileSelectCol
@@ -177,16 +177,73 @@ export default function CompareTable() {
           </th>
           {/**/}
           <Col plan={showFree}>
-            <CompareValue type="number">500</CompareValue>
+            <CompareValue type="number">1000</CompareValue>
           </Col>
           <Col plan={showPayg} feature>
-            <CompareValue type="number">500000</CompareValue>
+            <CompareValue>Unlimited</CompareValue>
           </Col>
-          <Col plan={showPro1}>
+          <Col plan={showFixed1}>
             <CompareValue>1M</CompareValue>
           </Col>
-          <Col plan={showPro10}>
+          <Col plan={showFixed10}>
             <CompareValue>10M</CompareValue>
+          </Col>
+        </tr>
+
+        {/*MAX MONTHLY BANDWIDTH*/}
+        <tr>
+          <th className="px-0 text-left font-normal">
+            <Tooltip content="The max total data size going out from QStash to user endpoints per month.">
+              Max Monthly Bandwidth
+            </Tooltip>
+          </th>
+          {/**/}
+          <Col plan={showFree}>
+            <CompareValue type="size" suffix="GB" className="border-b-0">
+              50
+            </CompareValue>
+          </Col>
+          <Col plan={showPayg} feature>
+            <CompareValue
+              type="size"
+              suffix="GB"
+              className="border-b-0"
+              after={
+                <Tooltip content="Free up to 50GB per month. Beyond that $0.05 per GB.">
+                  <IconInfoCircle className="ml-1" stroke={1.5} size={24} />
+                </Tooltip>
+              }
+            >
+              50
+            </CompareValue>
+          </Col>
+          <Col plan={showFixed1}>
+              <CompareValue
+                type="size"
+                suffix="TB"
+                className="border-b-0"
+                after={
+                  <Tooltip content="Free up to 1TB per month. Beyond that $0.05 per GB.">
+                    <IconInfoCircle className="ml-1" stroke={1.5} size={24} />
+                  </Tooltip>
+                }
+              >
+                1
+              </CompareValue>
+          </Col>
+          <Col plan={showFixed10}>
+              <CompareValue
+                type="size"
+                suffix="TB"
+                className="border-b-0"
+                after={
+                  <Tooltip content="Free up to 5TB per month. Beyond that $0.05 per GB.">
+                    <IconInfoCircle className="ml-1" stroke={1.5} size={24} />
+                  </Tooltip>
+                }
+              >
+                5
+              </CompareValue>
           </Col>
         </tr>
 
@@ -201,10 +258,10 @@ export default function CompareTable() {
           <Col plan={showPayg} feature>
             <CompareValue type="number">1000</CompareValue>
           </Col>
-          <Col plan={showPro1}>
+          <Col plan={showFixed1}>
             <CompareValue type="number">1000</CompareValue>
           </Col>
-          <Col plan={showPro10}>
+          <Col plan={showFixed10}>
             <CompareValue type="number">1000</CompareValue>
           </Col>
         </tr>
@@ -220,30 +277,11 @@ export default function CompareTable() {
           <Col plan={showPayg} feature>
             <CompareValue>Unlimited</CompareValue>
           </Col>
-          <Col plan={showPro1}>
+          <Col plan={showFixed1}>
             <CompareValue>Unlimited</CompareValue>
           </Col>
-          <Col plan={showPro10}>
+          <Col plan={showFixed10}>
             <CompareValue>Unlimited</CompareValue>
-          </Col>
-        </tr>
-
-        <tr>
-          <th className="px-0 py-4 text-left font-normal">
-            Max Requests per Second
-          </th>
-          {/**/}
-          <Col plan={showFree}>
-            <CompareValue type="number">100</CompareValue>
-          </Col>
-          <Col plan={showPayg} feature>
-            <CompareValue type="number">100</CompareValue>
-          </Col>
-          <Col plan={showPro1}>
-            <CompareValue type="number">500</CompareValue>
-          </Col>
-          <Col plan={showPro10}>
-            <CompareValue type="number">1000</CompareValue>
           </Col>
         </tr>
 
@@ -260,12 +298,12 @@ export default function CompareTable() {
               10
             </CompareValue>
           </Col>
-          <Col plan={showPro1}>
+          <Col plan={showFixed1}>
             <CompareValue type="size" suffix="MB">
               50
             </CompareValue>
           </Col>
-          <Col plan={showPro10}>
+          <Col plan={showFixed10}>
             <CompareValue type="size" suffix="MB">
               50
             </CompareValue>
@@ -281,10 +319,10 @@ export default function CompareTable() {
           <Col plan={showPayg} feature>
             <CompareValue>5</CompareValue>
           </Col>
-          <Col plan={showPro1}>
+          <Col plan={showFixed1}>
             <CompareValue>20</CompareValue>
           </Col>
-          <Col plan={showPro10}>
+          <Col plan={showFixed10}>
             <CompareValue>100</CompareValue>
           </Col>
         </tr>
@@ -298,10 +336,10 @@ export default function CompareTable() {
           <Col plan={showPayg} feature>
             <CompareValue>1 year</CompareValue>
           </Col>
-          <Col plan={showPro1}>
+          <Col plan={showFixed1}>
             <CompareValue>Unlimited</CompareValue>
           </Col>
-          <Col plan={showPro10}>
+          <Col plan={showFixed10}>
             <CompareValue>Unlimited</CompareValue>
           </Col>
         </tr>
@@ -317,10 +355,10 @@ export default function CompareTable() {
           <Col plan={showPayg} feature>
             <CompareValue>2 hours</CompareValue>
           </Col>
-          <Col plan={showPro1}>
+          <Col plan={showFixed1}>
             <CompareValue>6 hours</CompareValue>
           </Col>
-          <Col plan={showPro10}>
+          <Col plan={showFixed10}>
             <CompareValue>12 hours</CompareValue>
           </Col>
         </tr>
@@ -334,10 +372,10 @@ export default function CompareTable() {
           <Col plan={showPayg} feature>
             <CompareValue>7 days</CompareValue>
           </Col>
-          <Col plan={showPro1}>
+          <Col plan={showFixed1}>
             <CompareValue>30 days</CompareValue>
           </Col>
-          <Col plan={showPro10}>
+          <Col plan={showFixed10}>
             <CompareValue>3 months</CompareValue>
           </Col>
         </tr>
@@ -353,10 +391,10 @@ export default function CompareTable() {
           <Col plan={showPayg} feature>
             <CompareValue>7 days</CompareValue>
           </Col>
-          <Col plan={showPro1}>
+          <Col plan={showFixed1}>
             <CompareValue>14 days</CompareValue>
           </Col>
-          <Col plan={showPro10}>
+          <Col plan={showFixed10}>
             <CompareValue>14 days</CompareValue>
           </Col>
         </tr>
@@ -372,12 +410,12 @@ export default function CompareTable() {
           <Col plan={showPayg} feature>
             <CompareValue type="boolean" valid={false} />
           </Col>
-          <Col plan={showPro1}>
+          <Col plan={showFixed1}>
             <CompareValue className="">
               <div>99.99%</div>
             </CompareValue>
           </Col>
-          <Col plan={showPro10}>
+          <Col plan={showFixed10}>
             <CompareValue className="">
               <div>99.99%</div>
             </CompareValue>
@@ -397,10 +435,10 @@ export default function CompareTable() {
           <Col plan={showPayg} feature>
             <CompareValue>None</CompareValue>
           </Col>
-          <Col plan={showPro1}>
+          <Col plan={showFixed1}>
             <CompareValue>$180</CompareValue>
           </Col>
-          <Col plan={showPro10}>
+          <Col plan={showFixed10}>
             <CompareValue>$420</CompareValue>
           </Col>
         </tr>
@@ -413,10 +451,10 @@ export default function CompareTable() {
           <Col plan={showPayg} feature>
             <CompareValue>$1 per 100K</CompareValue>
           </Col>
-          <Col plan={showPro1}>
+          <Col plan={showFixed1}>
             <CompareValue>None</CompareValue>
           </Col>
-          <Col plan={showPro10}>
+          <Col plan={showFixed10}>
             <CompareValue>None</CompareValue>
           </Col>
         </tr>
@@ -439,14 +477,14 @@ export default function CompareTable() {
               </a>
             </Button>
           </Col>
-          <Col plan={showPro1} className="py-4">
+          <Col plan={showFixed1} className="py-4">
             <Button asChild variant="primary">
               <a target="_self" href="https://console.upstash.com/workflow">
                 Start Now
               </a>
             </Button>
           </Col>
-          <Col plan={showPro10} className="py-4">
+          <Col plan={showFixed10} className="py-4">
             <Button asChild variant="primary">
               <a target="_self" href="https://console.upstash.com/workflow">
                 Start Now
@@ -467,8 +505,8 @@ function MobileSelectCol({ ...props }: React.ComponentProps<"select">) {
     >
       <option value={PricingPlans.Free}>Free</option>
       <option value={PricingPlans.PayAsYouGo}>Pay as you go</option>
-      <option value={PricingPlans.Pro1M}>Pro 1M</option>
-      <option value={PricingPlans.Pro10M}>Pro 10M</option>
+      <option value={PricingPlans.Pro1M}>Fixed 1M</option>
+      <option value={PricingPlans.Pro10M}>Fixed 10M</option>
     </select>
   );
 }

--- a/src/components/pricing/workflow/faq.tsx
+++ b/src/components/pricing/workflow/faq.tsx
@@ -69,12 +69,43 @@ export default function FAQ() {
       </AccordionItem>
       <AccordionItem value="item-4">
         <AccordionTrigger>
-          What happens when request per second limit is reached?
+          Is there a rate limit ?
         </AccordionTrigger>
         <AccordionContent>
-          When the limit is reached QStash API starts to return exception, the Workflow SDK 
-          in this case throttles for a second and retries the call until the retry limit is reached.
-          After that, the workflow run fails and recorded in DLQ(dead letter queue).
+        <ul className="mt-4 list-disc space-y-2 pl-6">
+            <li className="space-y-2">
+              <p>
+                There is no request per second limit for operational API's as listed above:
+              </p>
+              <ul className="mt-4 list-disc space-y-2 pl-6">
+              <li> trigger, publish, enqueue, notify, wait, batch</li>
+              </ul>
+            </li>
+            <li className="space-y-2">
+              <p> Other endpoints (like logs,messages etc) have rps limit. When limit is reached, Rest API returns 
+                "Too Many Request" with 429 status code.
+              </p>
+              <ul className="mt-4 list-disc space-y-2 pl-6">
+              <li> Free: 100 rps</li>
+              <li> Pay as you go: 100 rps</li>
+              <li> Fixed 1M: 500 rps</li>
+              <li> Fixed 10M: 1000 rps</li>
+              </ul>
+            </li>
+            <li className="space-y-2">
+              <p>
+                We have parallelism limit when calling the user endpoint from QStash. 
+                This limits number of parallel calls that can happen at the same time, other calls are queued to be done 
+                later. The quotas per plan is as follows:
+              </p>
+                <ul className="mt-4 list-disc space-y-2 pl-6">
+                <li> Free: 10</li>
+                <li> Pay as you go: 100</li>
+                <li> Fixed 1M: 200</li>
+                <li> Fixed 10M: 1000 </li>
+              </ul>
+            </li>
+          </ul>
         </AccordionContent>
       </AccordionItem>
       <AccordionItem value="item-5">

--- a/src/components/pricing/workflow/pricing-table.tsx
+++ b/src/components/pricing/workflow/pricing-table.tsx
@@ -29,10 +29,6 @@ export default function PricingTable() {
             <p className="text-text-mute">Steps per Day</p>
             <p className="font-semibold">500</p>
           </div>
-          <div className="py-3">
-            <p className="text-text-mute">Requests per Second</p>
-            <p className="font-semibold">100</p>
-          </div>
         </div>
 
         <div>
@@ -65,11 +61,7 @@ export default function PricingTable() {
         <div className="w-full px-6 *:border-b *:border-bg-mute">
           <div className="py-3">
             <p className="text-text-mute">Steps per Day</p>
-            <p className="font-semibold">500,000</p>
-          </div>
-          <div className="py-3">
-            <p className="text-text-mute">Requests per Second</p>
-            <p className="font-semibold">100</p>
+            <p className="font-semibold">Unlimited</p>
           </div>
         </div>
 
@@ -82,11 +74,11 @@ export default function PricingTable() {
         </div>
       </div>
 
-      {/* Pro */}
+      {/* Fixed */}
 
       <div className="flex flex-col items-center gap-4 rounded-4xl bg-white p-6 shadow sm:gap-6 sm:p-8 dark:border-bg-mute dark:bg-bg-mute">
         <div className="grow">
-          <h4 className="mb-4 py-1 text-xl font-bold text-primary-text">Pro</h4>
+          <h4 className="mb-4 py-1 text-xl font-bold text-primary-text">Fixed</h4>
 
           <h5 className="flex items-baseline text-2xl font-semibold">
             $180
@@ -108,10 +100,6 @@ export default function PricingTable() {
           <div className="py-3">
             <p className="text-text-mute">Steps per Day</p>
             <p className="font-semibold">Up to 100M</p>
-          </div>
-          <div className="py-3">
-            <p className="text-text-mute">Requests per Second</p>
-            <p className="font-semibold">Up to 1000</p>
           </div>
         </div>
 


### PR DESCRIPTION
- Added charge for bandwidth. free: 50GB free, then limit payg: 50GB free, then $0.05 / GB
pro1m: 5TB free, then $0.05 / GB
pro1m: 10TB free, then $0.05 / GB
- Daily limit is removed from pay as you go.
- Daily limit of free plans are increased from 500 to 1000
- Max request per second is removed from critical API's
    - trigger, publish, enqueue, notify, wait, batch
    - mentioned in FAQ.
- Max parallelism is introduced
    - mentioned in FAQ.

Not included in this pr.
- Prod pack doc.