### PR TITLE
fix: change single quote to double in Redis example

### DIFF
--- a/src/components/home/serverless/http-rest-api.tsx
+++ b/src/components/home/serverless/http-rest-api.tsx
@@ -91,7 +91,7 @@ const redis = new Redis({
   token: "<UPSTASH_REDIS_REST_TOKEN>",
 })
    
-const data = await redis.set("foo', "bar");`,
+const data = await redis.set("foo", "bar");`,
   [Product.QSTASH]: `import { Client } from "@upstash/qstash";
 
 const client = new Client({


### PR DESCRIPTION
HTTP/REST API example is not good for Redis on the homepage

<img width="960" height="684" alt="image" src="https://github.com/user-attachments/assets/2b2c03b3-7f1d-41ea-9f23-293449f82ccd" />
