### PR TITLE
fix: correct landing page code snippets against current SDK docs

### DIFF
--- a/src/components/home/serverless/code-snippets-box.tsx
+++ b/src/components/home/serverless/code-snippets-box.tsx
@@ -11,11 +11,12 @@ const data: CodeSnippetsData = [
       {
         language: "js",
         code: `
-import { Box, ClaudeCode } from "@upstash/box"
+import { Box, Agent, ClaudeCode } from "@upstash/box"
 
 const box = await Box.create({
   runtime: "node",
   agent: {
+    provider: Agent.ClaudeCode,
     model: ClaudeCode.Opus_4_6,
     apiKey: process.env.ANTHROPIC_API_KEY,
   },
@@ -36,11 +37,12 @@ console.log(run.result)
       {
         language: "js",
         code: `
-import { Box, ClaudeCode } from "@upstash/box"
+import { Box, Agent, ClaudeCode } from "@upstash/box"
 
 const box = await Box.create({
   runtime: "node",
   agent: {
+    provider: Agent.ClaudeCode,
     model: ClaudeCode.Opus_4_6,
     apiKey: process.env.ANTHROPIC_API_KEY,
   },
@@ -65,12 +67,13 @@ await box.agent.run({
       {
         language: "js",
         code: `
-import { Box, ClaudeCode } from "@upstash/box"
+import { Box, Agent, ClaudeCode } from "@upstash/box"
 import { z } from "zod"
 
 const box = await Box.create({
   runtime: "node",
   agent: {
+    provider: Agent.ClaudeCode,
     model: ClaudeCode.Opus_4_6,
     apiKey: process.env.ANTHROPIC_API_KEY,
   },

--- a/src/components/home/serverless/code-snippets-qstash.tsx
+++ b/src/components/home/serverless/code-snippets-qstash.tsx
@@ -12,6 +12,7 @@ const data: CodeSnippetsData = [
         language: "js",
         code: `
 import { Client } from "@upstash/qstash";
+
 const client = new Client({ token: "<QSTASH_TOKEN>" });
 
 await client.schedules.create({
@@ -24,6 +25,7 @@ await client.schedules.create({
         language: "py",
         code: `
 from qstash import QStash
+
 client = QStash("<QSTASH_TOKEN>")
 
 client.schedule.create(
@@ -41,6 +43,7 @@ client.schedule.create(
         language: "js",
         code: `
 import { Client } from "@upstash/qstash";
+
 const client = new Client({ token: "<QSTASH_TOKEN>" });
 
 const res = await client.publishJSON({
@@ -54,6 +57,7 @@ const res = await client.publishJSON({
         language: "py",
         code: `
 from qstash import QStash
+
 client = QStash("<QSTASH_TOKEN>")
 
 client.message.publish_json(
@@ -72,6 +76,7 @@ client.message.publish_json(
         language: "js",
         code: `
 import { Client } from "@upstash/qstash";
+
 const client = new Client({ token: "<QSTASH_TOKEN>" });
 
 const queue = client.queue({
@@ -90,6 +95,7 @@ await queue.enqueueJSON({
         language: "py",
         code: `
 from qstash import QStash
+
 client = QStash("<QSTASH_TOKEN>")
 
 queue_name = "my-queue"
@@ -111,6 +117,7 @@ client.message.enqueue_json(
         language: "js",
         code: `
 import { Client } from "@upstash/qstash";
+
 const client = new Client({ token: "<QSTASH_TOKEN>" });
 
 const res = await client.publishJSON({
@@ -124,6 +131,7 @@ const res = await client.publishJSON({
         language: "py",
         code: `
 from qstash import QStash
+
 client = QStash("<QSTASH_TOKEN>")
 
 client.message.publish_json(

--- a/src/components/home/serverless/code-snippets-redis.tsx
+++ b/src/components/home/serverless/code-snippets-redis.tsx
@@ -12,15 +12,13 @@ const data: CodeSnippetsData = [
         language: "js",
         code: `
 import { Redis } from "@upstash/redis";
+
 const redis = Redis.fromEnv();
 
-const cacheKey = \`item:\${itemId}\`;
+const item = await redis.get("item:123");
 
-// Check cache
-const cachedItem = await redis.get(cacheKey);
-if (cachedItem) {
-  console.log("Cache hit");
-  return JSON.parse(cachedItem);
+if (item) {
+  return item;
 }
 `,
       },
@@ -31,13 +29,9 @@ from upstash_redis import Redis
 
 redis = Redis.from_env()
 
-cache_key = f"item:{item_id}"
-
-# Check cache
-cached_item = redis.get(cache_key)
-if cached_item:
-    print("Cache hit")
-    return json.loads(cached_item)
+item = redis.get("item:123")
+if item:
+    return item
 `,
       },
     ],
@@ -49,6 +43,7 @@ if cached_item:
         language: "js",
         code: `
 import { Redis } from "@upstash/redis";
+
 const redis = Redis.fromEnv();
 
 const getSession = async (key: string) => {
@@ -116,7 +111,7 @@ redis = Redis.from_env()
 
 ratelimit = Ratelimit(
     redis=redis,
-    limiter=SlidingWindow(max_requests=10, window=10, unit="s")
+    limiter=SlidingWindow(max_requests=10, window=10)
 )
 
 identifier = get_ip_address()
@@ -135,6 +130,7 @@ if not result.allowed:
         language: "js",
         code: `
 import { Redis } from "@upstash/redis";
+
 const redis = Redis.fromEnv();
 
 const LEADERBOARD_KEY = "game-leaderboard";
@@ -172,6 +168,7 @@ def get_top_players(top: int):
         language: "js",
         code: `
 import { Redis } from "@upstash/redis";
+
 const redis = Redis.fromEnv();
 
 const getChatHistoryKey = (userId: string) => \`chat-history:\${userId}\`;
@@ -191,6 +188,7 @@ export const getChatHistory = async (userId: string) =>
 from upstash_redis import Redis
 
 redis = Redis.from_env()
+
 def save_message(user_id: str, message: str) -> None:
     key = f"chat:{user_id}"
     redis.lpush(key, message)

--- a/src/components/home/serverless/code-snippets-search.tsx
+++ b/src/components/home/serverless/code-snippets-search.tsx
@@ -26,7 +26,7 @@ const results = await client.index("movies").search({
 results = client.index("movies").search(
   query="space opera with jedi",
   limit=5,
-  reranking=true
+  reranking=True
 )
 `,
       },
@@ -108,9 +108,9 @@ const results = await client.index("products").search({
         code: `
 index.upsert(
   documents=[{
-    id: "headphones-0",
-    content: { description: "Noise cancelling wireless headphones" },
-    metadata: { inStock: true, price: 299 },
+    "id": "headphones-0",
+    "content": {"description": "Noise cancelling wireless headphones"},
+    "metadata": {"inStock": True, "price": 299},
   }]
 )
 

--- a/src/components/home/serverless/code-snippets-vector.tsx
+++ b/src/components/home/serverless/code-snippets-vector.tsx
@@ -12,7 +12,8 @@ const data: CodeSnippetsData = [
         language: "js",
         code: `
 import { Index } from "@upstash/vector";
-const index = new Index.from_env()
+
+const index = new Index()
 
 const question = "What is Quantum Mechanics?"
 
@@ -26,7 +27,7 @@ const context = await index.query({
 const prompt = \`Question: \${question} - Context: \${JSON.stringify(context)}\`;
 
 const response = await openai.chat.completions.create({
-  model: "gpt-3.5-turbo",
+  model: "gpt-5.4",
   messages: [
     { 
       role: "system", 
@@ -44,6 +45,7 @@ const response = await openai.chat.completions.create({
         language: "py",
         code: `
 from upstash_vector import Index
+
 index = Index.from_env()
 
 question = "What is Quantum Mechanics?" 
@@ -58,7 +60,7 @@ context = index.query(
 prompt = f"Question: {question} - Context: {str(context)}"
 
 response = openai.chat.completions.create(
-    model="gpt-3.5-turbo",
+    model="gpt-5.4",
     messages=[
         {
             "role": "system",
@@ -80,11 +82,10 @@ response = openai.chat.completions.create(
       {
         language: "js",
         code: `
-import { Index } from "@upstash/vector";
 import { SemanticCache } from "@upstash/semantic-cache";
+import { Index } from "@upstash/vector";
 
-const index = new Index();
-const semanticCache = new SemanticCache({ index, minProximity: 0.95 });
+const semanticCache = new SemanticCache({ index: new Index(), minProximity: 0.95 });
 
 await semanticCache.set("Capital of Turkey", "Ankara");
 await semanticCache.set("year in which the Berlin wall fell", "1989");
@@ -126,7 +127,8 @@ result2 = cache.get("what's the year the Berlin wall destroyed?")
         language: "js",
         code: `
 import { Index } from "@upstash/vector";
-const index = new Index.from_env()
+
+const index = new Index()
 
 const documents = [
   { id: "doc1", data: "Upstash Vector is a scalable vector database." },
@@ -144,6 +146,7 @@ const results = await index.query({ data: query, topK: 3 });
         language: "py",
         code: `
 from upstash_vector import Index
+
 index = Index.from_env()
 
 documents = [

--- a/src/components/home/serverless/code-snippets-workflow.tsx
+++ b/src/components/home/serverless/code-snippets-workflow.tsx
@@ -29,7 +29,7 @@ const response = await context.api.openai.call(
     token: "OPENAI_API_KEY",
     operation: "chat.completions.create",
     body: {
-      model: "gpt-4o",
+      model: "gpt-5.4",
       messages: [
         { role: "user", content: \`Analyze this data chunk: \${JSON.stringify(dataset)}\` },
       ],
@@ -52,12 +52,13 @@ response = await context.call("download-dataset", url=dataset_url, method="GET")
 dataset = response.body
 
 # Step 3: Analyze the dataset with LLM
-response = await context.api.openai.call(
+response = await context.call(
     "call-openai",
-    token="OPENAI_API_KEY",
-    operation="chat.completions.create",
+    url="https://api.openai.com/v1/chat/completions",
+    method="POST",
+    headers={"authorization": f"Bearer {os.getenv('OPENAI_API_KEY')}"},
     body={
-        "model": "gpt-4o-mini",
+        "model": "gpt-5.4",
         "messages": [
             {
                 "role": "user",


### PR DESCRIPTION
- Redis: remove unnecessary JSON.parse/json.loads (SDKs auto-deserialize)
- Vector: fix `new Index.from_env()` to `new Index()` (JS SDK)
- Ratelimit: remove invalid `unit` param from Python SlidingWindow
- Search: fix Python syntax errors (lowercase bool, JS object literals)
- Workflow: replace Python `context.api.openai.call` with `context.call`
- Box: add missing `Agent` import and `provider: Agent.ClaudeCode`
- Simplify caching snippet, add blank lines after imports, use gpt-5.4