### PR TITLE
fix(blog): rss, middleware, and style follow-ups

### DIFF
--- a/src/app/blog/feed.xml/route.ts
+++ b/src/app/blog/feed.xml/route.ts
@@ -15,12 +15,24 @@ function escapeXml(value: string): string {
     .replace(/"/g, "&quot;");
 }
 
+function cdata(value: string): string {
+  return value.replaceAll("]]>", "]]]]><![CDATA[>");
+}
+
+function absolutizeHtmlUrls(html: string): string {
+  return html.replace(
+    /\b(href|src)="\/([^"]*)"/g,
+    (_match, attribute: string, path: string) =>
+      `${attribute}="${SITE_URL}/${path}"`,
+  );
+}
+
 async function markdownToHtml(markdown: string): Promise<string> {
   const file = await remark()
     .use(remarkGfm)
     .use(remarkHtml, { sanitize: false })
     .process(sanitizeMdx(markdown));
-  return String(file);
+  return absolutizeHtmlUrls(String(file));
 }
 
 export async function GET(): Promise<Response> {
@@ -41,13 +53,13 @@ export async function GET(): Promise<Response> {
         "Articles and tutorials on serverless technologies from Upstash and community";
       return `
     <item>
-      <title><![CDATA[${post.title}]]></title>
+      <title><![CDATA[${cdata(post.title)}]]></title>
       <link>${url}</link>
       <guid isPermaLink="true">${url}</guid>
       <pubDate>${new Date(post.date).toUTCString()}</pubDate>
-      <description><![CDATA[${description}]]></description>
-      <content:encoded><![CDATA[${html}]]></content:encoded>
-      <dc:creator><![CDATA[${author}]]></dc:creator>
+      <description><![CDATA[${cdata(description)}]]></description>
+      <content:encoded><![CDATA[${cdata(html)}]]></content:encoded>
+      <dc:creator><![CDATA[${cdata(author)}]]></dc:creator>
       ${post.tags.map((tag) => `<category>${escapeXml(tag)}</category>`).join("")}
     </item>`;
     }),

--- a/src/app/blog/tag/[tag]/page.tsx
+++ b/src/app/blog/tag/[tag]/page.tsx
@@ -1,13 +1,12 @@
-import Bg from "@/components/bg";
-import PostGridCard from "@/components/blog/grid-item";
+import PostCard from "@/components/blog/post-card";
 import Container from "@/components/container";
-import PageHeaderTitle from "@/components/page-header-title";
 import { normalizeTag, normalizeTagParam } from "@/utils/tags";
-import type { Post } from "@content";
 import { uniq } from "lodash";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { getData } from "../../utils/helpers";
+import { extractExcerpt, getData } from "../../utils/helpers";
+
+const COLS = 3;
 
 type Props = {
   params: {
@@ -47,7 +46,7 @@ export async function generateMetadata({
   };
 }
 
-export default async function BlogPage({ params: { tag } }: Props) {
+export default async function BlogTagPage({ params: { tag } }: Props) {
   const normalized = normalizeTagParam(tag);
   const posts = await getData();
   const postsWithTag = posts.filter((post) =>
@@ -58,31 +57,50 @@ export default async function BlogPage({ params: { tag } }: Props) {
     notFound();
   }
 
+  const fillers = (COLS - (postsWithTag.length % COLS)) % COLS;
+
   return (
     <main className="relative z-0">
-      <Bg />
+      <Container className="pt-16 md:pt-24">
+        <div className="w-fit py-10 pl-7 pr-10 text-text md:pl-10 md:pr-20">
+          <h1 className="font-display text-4xl font-semibold leading-[1.1] tracking-tight md:text-5xl">
+            Articles tagged {normalized}.
+          </h1>
+        </div>
 
-      <header className="py-12 text-center md:py-24">
-        <PageHeaderTitle>
-          <span className="font-medium opacity-40">blog/tag/</span>
-          <span className="font-bold">{normalized}</span>
-        </PageHeaderTitle>
-        <div className="mt-4">
-          <Link className="text-primary-text hover:underline" href="/blog">
-            Back to all posts
+        <div className="mb-6 pl-7 md:pl-10">
+          <Link
+            href="/blog"
+            className="font-mono text-sm tracking-tight text-text-mute hover:text-text"
+          >
+            ← Back to all posts
           </Link>
         </div>
-      </header>
 
-      <section>
-        <Container>
-          <div className="grid gap-4 md:grid-cols-2 md:gap-8">
-            {postsWithTag.map((post: Post) => {
-              return <PostGridCard key={post.slug} data={post} />;
-            })}
+        <div className="bg-emerald-950/10 p-px dark:bg-white/10">
+          <div className="grid gap-px md:grid-cols-2 lg:grid-cols-3">
+            {postsWithTag.map((post) => (
+              <PostCard
+                key={post.slug}
+                data={{
+                  slug: post.slug,
+                  title: post.title,
+                  tags: post.tags,
+                  date: post.date,
+                  authorsData: post.authorsData,
+                  description: post.description,
+                  excerpt: post.description
+                    ? undefined
+                    : extractExcerpt(post.content),
+                }}
+              />
+            ))}
+            {Array.from({ length: fillers }).map((_, i) => (
+              <div key={`filler-${i}`} className="bg-bg" aria-hidden />
+            ))}
           </div>
-        </Container>
-      </section>
+        </div>
+      </Container>
     </main>
   );
 }

--- a/src/components/post/note.tsx
+++ b/src/components/post/note.tsx
@@ -1,58 +1,77 @@
 import cx from "@/utils/cx";
 import { ReactNode, SVGProps } from "react";
 
+type NoteType = "tip" | "info" | "caution" | "danger";
+
 export default function PostNote({
   children,
   type,
   title,
 }: {
   children: ReactNode;
-  type?: "tip" | "info" | "caution" | "danger";
+  type?: NoteType;
   title?: string;
 }) {
-  const style = {
+  const wrapperStyle = {
     caution:
-      "border-orange-800/10 bg-orange-500/10 text-orange-700 " +
-      "dark:bg-orange-500/20 dark:text-orange-200 dark:border-orange-500/10",
+      "bg-orange-500/10 text-orange-800 dark:bg-orange-500/15 dark:text-orange-100",
     danger:
-      "border-red-800/10 bg-red-500/10 text-red-700 " +
-      "dark:bg-red-500/20 dark:text-red-200 dark:border-red-500/10",
+      "bg-red-500/10 text-red-800 dark:bg-red-500/15 dark:text-red-100",
+  };
+
+  const labelStyle = {
+    caution: "text-orange-700 dark:text-orange-300",
+    danger: "text-red-700 dark:text-red-300",
   };
 
   const icon = {
+    tip: <PostNoteInfo />,
+    info: <PostNoteInfo />,
     caution: <PostNoteCaution />,
     danger: <PostNoteDanger />,
   };
 
+  const defaultLabel: Record<NoteType, string> = {
+    tip: "Tip",
+    info: "Note",
+    caution: "Caution",
+    danger: "Warning",
+  };
+
+  const label = title ?? defaultLabel[type ?? "info"];
+
   return (
     <div
       className={cx(
-        "flex items-start gap-4 rounded-xl border p-5 md:p-6",
-        "border-emerald-900/10 bg-emerald-800/5 text-emerald-900",
-        "dark:border-emerald-500/10 dark:bg-emerald-700/20 dark:text-emerald-50",
-        type && style[type],
+        "-mx-5 my-6 rounded-2xl p-5 md:-mx-6 md:p-6",
+        "bg-emerald-900/5 text-text dark:bg-white/[0.04]",
+        type && wrapperStyle[type],
       )}
     >
-      <span className="text-2xl">
-        {(type && icon[type]) || <PostNoteDefault />}
-      </span>
-
-      <div className="-mt-0.5">
-        {title && <h6 className="mb-1 font-display font-semibold">{title}</h6>}
-        {children}
+      <div
+        className={cx(
+          "mb-3 flex items-center gap-2 font-mono text-xs font-semibold uppercase tracking-wider",
+          "text-primary",
+          type && labelStyle[type],
+        )}
+      >
+        {icon[type ?? "info"]}
+        {label}
       </div>
+      <div>{children}</div>
     </div>
   );
 }
 
-function PostNoteDefault(props: SVGProps<SVGSVGElement>) {
+function PostNoteInfo(props: SVGProps<SVGSVGElement>) {
   return (
     <svg
+      aria-hidden="true"
       xmlns="http://www.w3.org/2000/svg"
-      width="1em"
-      height="1em"
+      width="14"
+      height="14"
       viewBox="0 0 24 24"
-      strokeWidth="1.5"
+      strokeWidth="2.5"
       stroke="currentColor"
       fill="none"
       strokeLinecap="round"
@@ -69,11 +88,12 @@ function PostNoteDefault(props: SVGProps<SVGSVGElement>) {
 function PostNoteCaution(props: SVGProps<SVGSVGElement>) {
   return (
     <svg
+      aria-hidden="true"
       xmlns="http://www.w3.org/2000/svg"
-      width="1em"
-      height="1em"
+      width="14"
+      height="14"
       viewBox="0 0 24 24"
-      strokeWidth="1.5"
+      strokeWidth="2.5"
       stroke="currentColor"
       fill="none"
       strokeLinecap="round"
@@ -89,11 +109,12 @@ function PostNoteCaution(props: SVGProps<SVGSVGElement>) {
 function PostNoteDanger(props: SVGProps<SVGSVGElement>) {
   return (
     <svg
+      aria-hidden="true"
       xmlns="http://www.w3.org/2000/svg"
-      width="1em"
-      height="1em"
+      width="14"
+      height="14"
       viewBox="0 0 24 24"
-      strokeWidth="1.5"
+      strokeWidth="2.5"
       stroke="currentColor"
       fill="none"
       strokeLinecap="round"

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,7 +4,7 @@ import { AFFILIATE_CODE } from "./constants";
 import { negotiate } from "@/lib/accept";
 
 function isBlogPath(pathname: string): boolean {
-  return pathname === "/blog" || /^\/blog\/[^/]+$/.test(pathname);
+  return pathname === "/blog" || /^\/blog\/[^/.]+$/.test(pathname);
 }
 
 const BLOG_MD_POST = /^\/blog\/([^/]+)\.md$/;

--- a/src/styles/code.css
+++ b/src/styles/code.css
@@ -17,6 +17,44 @@
 
 [data-rehype-pretty-code-figure] pre {
   @apply overflow-x-auto py-5;
+  scrollbar-width: thin;
+  scrollbar-color: rgb(2 44 34 / 0.2) transparent;
+}
+
+@media (prefers-color-scheme: dark) {
+  [data-rehype-pretty-code-figure] pre {
+    scrollbar-color: rgb(255 255 255 / 0.15) transparent;
+  }
+}
+
+[data-rehype-pretty-code-figure] pre::-webkit-scrollbar {
+  height: 8px;
+  width: 8px;
+}
+
+[data-rehype-pretty-code-figure] pre::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+[data-rehype-pretty-code-figure] pre::-webkit-scrollbar-thumb {
+  background-color: rgb(2 44 34 / 0.18);
+  border-radius: 9999px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+
+[data-rehype-pretty-code-figure] pre::-webkit-scrollbar-thumb:hover {
+  background-color: rgb(2 44 34 / 0.3);
+  background-clip: padding-box;
+}
+
+@media (prefers-color-scheme: dark) {
+  [data-rehype-pretty-code-figure] pre::-webkit-scrollbar-thumb {
+    background-color: rgb(255 255 255 / 0.15);
+  }
+  [data-rehype-pretty-code-figure] pre::-webkit-scrollbar-thumb:hover {
+    background-color: rgb(255 255 255 / 0.25);
+  }
 }
 
 [data-rehype-pretty-code-figure] code {


### PR DESCRIPTION
summarized by agent:

- **`fix(blog)`: exclude dotted paths from blog html middleware** — Tightens `isBlogPath` regex so `/blog/feed.xml` (and other dotted paths) no longer fall into the HTML branch and get bogus `Vary`/`Link`/`x-content-bucket: html` headers.
- **`fix(blog)`: escape CDATA and absolutize URLs in RSS feed** — Splits literal `]]>` inside CDATA bodies so XML stays valid, and rewrites relative `href`/`src` to absolute URLs so RSS readers resolve assets correctly.
- **`fix(style)`: match note callout to summary layout** — Restructures the in-article `<Note>` component to mirror the article summary box (icon + label header, body below). Caution/danger variants keep their semantic colors; existing MDX usage works unchanged.
- **`fix(style)`: thin scrollbars for code blocks** — Replaces the default chunky scrollbar with a thin rounded thumb on a transparent track, tuned for light and dark themes.
- **`fix(style)`: align blog tag page with overview layout** — Switches `/blog/tag/:tag` from the `Bg` + `PageHeaderTitle` + `PostGridCard` layout to the same Container/heading/back-link/bordered-grid pattern as `/blog` and `/blog/author/:author`, using `PostCard`.