### PR TITLE
Feature Multi-Zone HA on Redis Prod Pack surfaces

### DIFF
--- a/public/faq/redis.json
+++ b/public/faq/redis.json
@@ -66,7 +66,7 @@
     },
     {
       "question": "What is included in Prod Pack?",
-      "answer": "Prod Pack includes uptime SLA, SOC 2 Type 2 report, advanced monitoring with Prometheus, Grafana, and Datadog, high availability for read regions, role-based access control, and encryption at rest."
+      "answer": "Prod Pack includes uptime SLA, SOC 2 Type 2 report, advanced monitoring with Prometheus, Grafana, and Datadog, multi-zone high availability, role-based access control, and encryption at rest."
     },
     {
       "question": "What is included in Enterprise subscription?",

--- a/src/components/pricing/redis/faq.tsx
+++ b/src/components/pricing/redis/faq.tsx
@@ -261,8 +261,8 @@ export default function FAQ() {
         <AccordionTrigger>What is included in Prod Pack?</AccordionTrigger>
         <AccordionContent>
           Prod Pack includes uptime SLA, SOC 2 Type 2 report, advanced
-          monitoring with Prometheus, Grafana, and Datadog, high availability
-          for read regions, and encryption at rest.
+          monitoring with Prometheus, Grafana, and Datadog, multi-zone high
+          availability, and encryption at rest.
         </AccordionContent>
       </AccordionItem>
 

--- a/src/components/pricing/redis/prod-pack.tsx
+++ b/src/components/pricing/redis/prod-pack.tsx
@@ -16,6 +16,7 @@ export default function PricingTableProductionPack() {
         <ul className="flex flex-shrink flex-wrap items-center justify-center gap-1 md:items-start md:justify-start">
           {[
             "Uptime SLA",
+            "Multi-Zone HA",
             "Encryption at Rest",
             "SOC-2",
             "Prometheus",

--- a/src/data/pricing/redis.ts
+++ b/src/data/pricing/redis.ts
@@ -426,12 +426,11 @@ export const REDIS_PROD_PACK = {
     "Prod Pack is an add-on available for any paid plan (Pay as You Go or Fixed). Enable it from your database details page in the Upstash console.",
   features: [
     "Uptime SLA",
+    "Multi-Zone High Availability (regions deployed across multiple availability zones, with automatic same-region failover if a zone or replica fails)",
     "SOC 2 Type 2 report",
     "Advanced monitoring (Prometheus, Grafana, Datadog, New Relic)",
-    "High availability for read regions",
     "Role-based access control",
     "Encryption at rest",
-    "Multi-Zone HA",
   ],
 };
 


### PR DESCRIPTION
## Summary
- Add **Multi-Zone HA** pill to the Redis Prod Pack card on the pricing page
- Update the Redis pricing FAQ (both the React component and `public/faq/redis.json`) to say "multi-zone high availability" instead of the older "high availability for read regions"
- Replace the matching bullet in `REDIS_PROD_PACK.features` (which feeds `pricing/redis.md`) with a fuller Multi-Zone HA description

The Redis compare table already had a `Multi-Zone HA` row backed by `multiZoneHA: "with-prod-pack"`, so no data changes were needed there.

Scope is Redis-only — QStash/Workflow Prod Pack surfaces are untouched.

## Test plan
- [ ] Visit `/pricing/redis` and confirm the Prod Pack card lists "Multi-Zone HA" between "Uptime SLA" and "Encryption at Rest"
- [ ] Expand the "What is included in Prod Pack?" FAQ and confirm new wording
- [ ] Fetch `/pricing/redis.md` and confirm the Prod Pack Add-on section includes the Multi-Zone HA bullet
- [ ] Confirm `/faq/redis.json` returns updated answer

🤖 Generated with [Claude Code](https://claude.com/claude-code)