### PR TITLE
DX-2714: add /redis landing page targeting redis database keyword

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -12,7 +12,7 @@ module.exports = {
       return { loc: path, changefreq: "daily", priority: 1.0, lastmod: new Date().toISOString() };
     }
 
-    if (["/pricing", "/enterprise", "/contact", "/about"].includes(path)) {
+    if (["/pricing", "/redis", "/enterprise", "/contact", "/about"].includes(path)) {
       return { loc: path, changefreq: "weekly", priority: 0.9, lastmod: new Date().toISOString() };
     }
 

--- a/src/app/redis/faq.ts
+++ b/src/app/redis/faq.ts
@@ -1,0 +1,38 @@
+// Questions mirror real search intent for "redis database".
+export const REDIS_FAQ = [
+  {
+    question: "Is Redis a database?",
+    answer:
+      "Yes. Redis is an in-memory, key-value database. It keeps data in memory for sub-millisecond reads and writes and supports data structures such as strings, hashes, lists, sets, sorted sets, streams, and JSON.",
+  },
+  {
+    question: "Is Redis a SQL or NoSQL database?",
+    answer:
+      "Redis is a NoSQL database. Instead of tables and SQL queries, it stores data as keys mapped to values and data structures, which makes it fast and flexible for caching, queues, sessions, and real-time workloads.",
+  },
+  {
+    question: "What is a serverless Redis database?",
+    answer:
+      "A serverless Redis database removes server and cluster management. With Upstash you create a database in seconds, connect over HTTP or the Redis protocol, and pay per request instead of paying for always-on instances. It scales automatically with your traffic.",
+  },
+  {
+    question: "What can I use a Redis database for?",
+    answer:
+      "Almost anything that needs fast reads and writes. Caching, session storage, rate limiting, job queues, streams, leaderboards, pub/sub messaging, real-time analytics, feature flags, and memory for AI agents are just the start. Because Redis ships with so many data structures, teams keep finding new uses for it, and a single database can power several of these at once.",
+  },
+  {
+    question: "Is Upstash Redis good for agentic coding?",
+    answer:
+      "Yes. Upstash Redis is a strong fit for AI agents and agentic development. The HTTP REST API works from any runtime without connection pools, the SDKs are small and easy to call, and you can create a database in seconds and pay only per request. Agents can store short-term and long-term memory, cache results, and coordinate work without any infrastructure setup. You can also add the Upstash skill to your coding agent so it knows how to use Redis correctly.",
+  },
+  {
+    question: "Is Upstash Redis fully managed?",
+    answer:
+      "Yes. Upstash handles provisioning, replication, durability, backups, and scaling. You get a global, highly available Redis database without operating any servers.",
+  },
+  {
+    question: "How much does an Upstash Redis database cost?",
+    answer:
+      "Upstash Redis has a free tier for prototypes, pay-as-you-go pricing from $0.20 per 100K commands, and fixed monthly plans. You only pay for what you use. See the pricing page for current plans.",
+  },
+];

--- a/src/app/redis/page.tsx
+++ b/src/app/redis/page.tsx
@@ -1,0 +1,64 @@
+import SectionCta from "@/app/redis/section-cta";
+import SectionFaq from "@/app/redis/section-faq";
+import SectionFeatures from "@/app/redis/section-features";
+import SectionHero from "@/app/redis/section-hero";
+import SectionSkills from "@/app/redis/section-skills";
+import SectionUseCases from "@/app/redis/section-use-cases";
+import SectionWhatIs from "@/app/redis/section-what-is";
+import { REDIS_FAQ } from "@/app/redis/faq";
+import { generateFaqSchema } from "@/utils/structured-schema-generators";
+import { Metadata } from "next";
+
+const title = "Redis Database - Upstash";
+const description =
+  "Upstash is a serverless Redis database with low latency, durable storage, and pay-as-you-go pricing. Create a fully managed Redis database in seconds.";
+
+export const metadata: Metadata = {
+  title,
+  description,
+  keywords: [
+    "redis database",
+    "serverless redis",
+    "managed redis",
+    "redis cache",
+    "redis cloud",
+    "kv database",
+  ],
+  alternates: {
+    canonical: "/redis",
+  },
+  openGraph: {
+    type: "website",
+    title,
+    description,
+    url: "/redis",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title,
+    description,
+  },
+};
+
+export default function RedisPage() {
+  const faqSchema = generateFaqSchema({ faq: REDIS_FAQ });
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: faqSchema }}
+      />
+
+      <main className="text-center">
+        <SectionHero />
+        <SectionFeatures />
+        <SectionUseCases />
+        <SectionSkills />
+        <SectionWhatIs />
+        <SectionFaq items={REDIS_FAQ} />
+        <SectionCta />
+      </main>
+    </>
+  );
+}

--- a/src/app/redis/section-cta.tsx
+++ b/src/app/redis/section-cta.tsx
@@ -1,0 +1,41 @@
+import Bg from "@/components/bg";
+import Button from "@/components/button";
+import Container from "@/components/container";
+import cx from "@/utils/cx";
+import Link from "next/link";
+
+export default function SectionCta() {
+  return (
+    <section className="relative py-16 md:py-28">
+      <Bg className="top-32 h-1/2" />
+
+      <Container className="max-w-screen-md">
+        <h2
+          className={cx(
+            "font-display text-3xl font-bold md:text-5xl",
+            "bg-gradient-to-r bg-clip-text text-transparent",
+            "from-primary-text via-primary to-amber-500",
+          )}
+        >
+          Start your Redis database in seconds
+        </h2>
+
+        <p className="mx-auto mt-4 max-w-xl text-balance text-lg text-text-mute md:text-xl">
+          Create a serverless Redis database on the free tier. No credit card
+          required.
+        </p>
+
+        <div className="mt-10 flex flex-col justify-center gap-3 sm:flex-row">
+          <Button asChild variant="primary" className="h-[46px] px-6">
+            <a href="https://console.upstash.com/redis" target="_blank">
+              Create Database
+            </a>
+          </Button>
+          <Button asChild variant="default" className="h-[46px] px-6">
+            <Link href="/pricing/redis">View Pricing</Link>
+          </Button>
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/src/app/redis/section-faq.tsx
+++ b/src/app/redis/section-faq.tsx
@@ -1,0 +1,32 @@
+import Bg from "@/components/bg";
+import Container from "@/components/container";
+import PageHeaderTitle from "@/components/page-header-title";
+
+export default function SectionFaq({
+  items,
+}: {
+  items: { question: string; answer: string }[];
+}) {
+  return (
+    <section className="relative py-10 md:py-20">
+      <Bg className="top-32 h-1/2" />
+
+      <Container className="max-w-screen-md text-left">
+        <PageHeaderTitle as="h2" className="text-center">
+          Frequently asked questions
+        </PageHeaderTitle>
+
+        <div className="mt-10 divide-y divide-bg-mute md:mt-14">
+          {items.map(({ question, answer }, index) => (
+            <div key={index} className="py-6">
+              <h3 className="font-display text-lg font-semibold md:text-xl">
+                {question}
+              </h3>
+              <p className="mt-2 text-text-mute">{answer}</p>
+            </div>
+          ))}
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/src/app/redis/section-features.tsx
+++ b/src/app/redis/section-features.tsx
@@ -1,0 +1,99 @@
+import Bg from "@/components/bg";
+import Container from "@/components/container";
+import PageHeaderDesc from "@/components/page-header-desc";
+import PageHeaderTitle from "@/components/page-header-title";
+import cx from "@/utils/cx";
+import {
+  IconApi,
+  IconArrowsMaximize,
+  IconBolt,
+  IconDatabase,
+  IconPlugConnected,
+  IconServer2,
+  IconShieldLock,
+  IconWorld,
+} from "@tabler/icons-react";
+import React from "react";
+
+export default function SectionFeatures() {
+  return (
+    <section className="relative py-10 md:py-20">
+      <Bg className="top-32 h-1/2" />
+
+      <Container className="max-w-screen-xl">
+        <PageHeaderTitle as="h2">Why Upstash Redis</PageHeaderTitle>
+        <PageHeaderDesc className="mt-3">
+          A serverless Redis database built for modern, global applications.
+        </PageHeaderDesc>
+
+        <div className="mt-12 grid gap-3 text-left sm:grid-cols-2 md:mt-16 md:gap-4 xl:grid-cols-4">
+          {FEATURES.map(({ title, desc, icon }, index) => (
+            <div
+              key={index}
+              className={cx(
+                "flex flex-col gap-3 p-5 md:p-6",
+                "rounded-3xl border-2 border-bg-mute bg-bg-mute",
+              )}
+            >
+              <span
+                className={cx(
+                  "inline-flex size-10 shrink-0 items-center justify-center",
+                  "rounded-full bg-primary text-white dark:bg-white/10",
+                )}
+              >
+                {icon}
+              </span>
+              <h3 className="whitespace-nowrap font-display text-lg font-semibold">
+                {title}
+              </h3>
+              <p className="text-text-mute">{desc}</p>
+            </div>
+          ))}
+        </div>
+      </Container>
+    </section>
+  );
+}
+
+const FEATURES = [
+  {
+    icon: <IconBolt className="size-5" stroke={1.5} />,
+    title: "Serverless & pay-per-request",
+    desc: "No servers to provision. Pay only for the commands you run, and scale to zero when idle.",
+  },
+  {
+    icon: <IconWorld className="size-5" stroke={1.5} />,
+    title: "Global, low latency",
+    desc: "Replicate your database across regions for single-digit millisecond reads close to your users.",
+  },
+  {
+    icon: <IconDatabase className="size-5" stroke={1.5} />,
+    title: "Durable storage",
+    desc: "Data is persisted and replicated, so your Redis database survives restarts and failures.",
+  },
+  {
+    icon: <IconApi className="size-5" stroke={1.5} />,
+    title: "REST API over HTTP",
+    desc: "Connect from serverless and edge functions over HTTP, with no connection pools to manage.",
+  },
+  {
+    icon: <IconServer2 className="size-5" stroke={1.5} />,
+    title: "High availability",
+    desc: "Multi-zone replication with automatic failover keeps your database online.",
+  },
+  {
+    icon: <IconPlugConnected className="size-5" stroke={1.5} />,
+    title: "Redis API compatible",
+    desc: "Use the Redis commands and clients you already know. Works with existing Redis tooling.",
+  },
+  {
+    icon: <IconShieldLock className="size-5" stroke={1.5} />,
+    title: "Secure by default",
+    desc: "TLS encryption, encryption at rest, IP allowlists, and SOC2 / HIPAA compliance.",
+  },
+  {
+    icon: <IconArrowsMaximize className="size-5" stroke={1.5} />,
+    title: "Auto-scaling",
+    desc: "Throughput and storage grow automatically with your traffic, so there is no manual resizing.",
+  },
+];

--- a/src/app/redis/section-hero.tsx
+++ b/src/app/redis/section-hero.tsx
@@ -1,0 +1,61 @@
+import Bg from "@/components/bg";
+import Button from "@/components/button";
+import Container from "@/components/container";
+import IconRedis from "@/components/icon-redis";
+import cx from "@/utils/cx";
+import { IconNotes, IconPlus } from "@tabler/icons-react";
+import Link from "next/link";
+
+export default function SectionHero() {
+  return (
+    <section className="relative py-10 md:py-24">
+      <Bg className="top-32 h-1/2" />
+
+      <Container className="max-w-screen-lg">
+        <div className="grid place-items-center">
+          <h1
+            className={cx(
+              "flex flex-col items-center gap-4 md:gap-6",
+              "text-center font-display text-4xl font-bold md:text-7xl",
+              "bg-gradient-to-r bg-clip-text text-transparent",
+              "from-primary-text via-primary to-amber-300",
+            )}
+          >
+            <IconRedis className="size-12 shrink-0 md:size-20" />
+            <span>
+              <span className="block">Serverless</span>
+              <span className="block">Redis Database</span>
+            </span>
+          </h1>
+
+          <p className="mt-6 max-w-2xl text-balance text-lg text-text-mute md:text-2xl">
+            Upstash runs Redis as a fully managed, serverless database with
+            single-digit millisecond latency and durable storage. You pay only
+            for what you use, and there are no servers to run. Connect over HTTP
+            or the standard Redis protocol.
+          </p>
+
+          <div className="mt-10 flex flex-col justify-center gap-3 sm:flex-row">
+            <a href="https://console.upstash.com/redis" target="_blank">
+              <Button variant="primary" className="h-[42px] px-5">
+                Create Database
+                <IconPlus size={24} />
+              </Button>
+            </a>
+            <a href="https://upstash.com/docs/redis" target="_blank">
+              <Button variant="defaultDark" className="h-[42px] px-5">
+                Documentation
+                <IconNotes size={24} />
+              </Button>
+            </a>
+            <Link href="/pricing/redis">
+              <Button variant="default" className="h-[42px] px-5">
+                View Pricing
+              </Button>
+            </Link>
+          </div>
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/src/app/redis/section-skills.tsx
+++ b/src/app/redis/section-skills.tsx
@@ -1,0 +1,47 @@
+import Bg from "@/components/bg";
+import Container from "@/components/container";
+import CopyButton from "@/components/copy-button";
+import OutLink from "@/components/out-link";
+import PageHeaderDesc from "@/components/page-header-desc";
+import PageHeaderTitle from "@/components/page-header-title";
+import cx from "@/utils/cx";
+
+const INSTALL_COMMAND =
+  "npx skills add https://github.com/upstash/skills --skill upstash";
+
+export default function SectionSkills() {
+  return (
+    <section className="relative py-10 md:py-20">
+      <Bg className="top-32 h-1/2" />
+
+      <Container className="max-w-screen-md">
+        <PageHeaderTitle as="h2">Build Redis with your AI agent</PageHeaderTitle>
+        <PageHeaderDesc className="mt-3">
+          Install the Upstash skill so Claude Code, Cursor, and other coding
+          agents know how to build with Upstash Redis and every Upstash SDK.
+        </PageHeaderDesc>
+
+        <div
+          className={cx(
+            "mx-auto mt-10 flex w-fit max-w-full items-center gap-4 overflow-x-auto",
+            "rounded-2xl border-2 border-bg-mute bg-bg-mute py-4 pl-5 pr-8",
+          )}
+        >
+          <code className="whitespace-nowrap text-left font-mono text-sm text-text md:text-base">
+            {INSTALL_COMMAND}
+          </code>
+          <CopyButton
+            code={INSTALL_COMMAND}
+            className="shrink-0 text-text-mute hover:text-primary"
+          />
+        </div>
+
+        <div className="mt-6 flex justify-center">
+          <OutLink href="https://github.com/upstash/skills">
+            View the Upstash skills on GitHub
+          </OutLink>
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/src/app/redis/section-use-cases.tsx
+++ b/src/app/redis/section-use-cases.tsx
@@ -1,0 +1,79 @@
+import Bg from "@/components/bg";
+import Container from "@/components/container";
+import PageHeaderDesc from "@/components/page-header-desc";
+import PageHeaderTitle from "@/components/page-header-title";
+import cx from "@/utils/cx";
+import { IconArrowUpRight } from "@tabler/icons-react";
+
+export default function SectionUseCases() {
+  return (
+    <section className="relative py-10 md:py-20">
+      <Bg className="top-32 h-1/2" />
+
+      <Container className="max-w-screen-xl">
+        <PageHeaderTitle as="h2">What can you build with Redis?</PageHeaderTitle>
+        <PageHeaderDesc className="mt-3">
+          Common Redis database use cases, with guides to build each one.
+        </PageHeaderDesc>
+
+        <div className="mt-12 grid gap-3 text-left sm:grid-cols-2 md:mt-16 md:grid-cols-3 md:gap-4">
+          {USE_CASES.map(({ title, desc, href }, index) => (
+            <a
+              key={index}
+              href={href}
+              target="_blank"
+              className={cx(
+                "group flex flex-col gap-2 p-6",
+                "rounded-3xl border-2 border-bg-mute bg-bg-mute",
+                "transition hover:border-primary/40 hover:bg-white dark:hover:bg-white/5",
+              )}
+            >
+              <h3 className="flex items-center gap-1 font-display text-lg font-semibold">
+                {title}
+                <IconArrowUpRight
+                  size={18}
+                  className="opacity-40 transition group-hover:opacity-100"
+                />
+              </h3>
+              <p className="text-text-mute">{desc}</p>
+            </a>
+          ))}
+        </div>
+      </Container>
+    </section>
+  );
+}
+
+// Internal links into existing docs/blog content build a Redis topic cluster.
+const USE_CASES = [
+  {
+    title: "Caching",
+    desc: "Cache database queries and API responses to cut latency and load on your primary database.",
+    href: "https://upstash.com/docs/redis/tutorials/nextjs_with_redis",
+  },
+  {
+    title: "Rate limiting",
+    desc: "Protect your APIs with fast, distributed rate limiting using the Upstash Ratelimit SDK.",
+    href: "https://upstash.com/docs/redis/sdks/ratelimit-ts/overview",
+  },
+  {
+    title: "Queues & streams",
+    desc: "Build FIFO, delayed, and prioritized job queues on Redis lists, sorted sets, and streams.",
+    href: "https://upstash.com/docs/redis/tutorials/redis_queue",
+  },
+  {
+    title: "Session storage",
+    desc: "Store user sessions for fast, stateless authentication across serverless functions.",
+    href: "https://upstash.com/docs/redis/tutorials/express_session",
+  },
+  {
+    title: "Search",
+    desc: "Add full-text and vector search to your app with Redis Search.",
+    href: "https://upstash.com/docs/redis/search/introduction",
+  },
+  {
+    title: "AI agent memory",
+    desc: "Give AI agents fast short-term and long-term memory with a serverless Redis database.",
+    href: "https://upstash.com/docs/redis/tutorials/agent_memory",
+  },
+];

--- a/src/app/redis/section-what-is.tsx
+++ b/src/app/redis/section-what-is.tsx
@@ -1,0 +1,44 @@
+import Bg from "@/components/bg";
+import Container from "@/components/container";
+import PageHeaderDesc from "@/components/page-header-desc";
+import PageHeaderTitle from "@/components/page-header-title";
+
+export default function SectionWhatIs() {
+  return (
+    <section className="relative py-10 md:py-20">
+      <Bg className="top-32 h-1/2" />
+
+      <Container className="max-w-screen-md text-left">
+        <PageHeaderTitle as="h2" className="text-center">
+          What is a Redis database?
+        </PageHeaderTitle>
+        <PageHeaderDesc className="mt-3 text-center">
+          A fast, in-memory key-value store for real-time applications.
+        </PageHeaderDesc>
+
+        <div className="mt-10 space-y-5 text-lg leading-relaxed text-text-mute">
+          <p>
+            A <strong>Redis database</strong> is an in-memory, key-value data
+            store. Because it keeps data in RAM instead of on disk, reads and
+            writes finish in well under a millisecond. That speed is why teams
+            reach for Redis to handle caching, rate limiting, and queues.
+          </p>
+          <p>
+            Redis is a NoSQL database. It supports data structures like strings,
+            hashes, lists, sets, sorted sets, streams, and JSON, so it can do
+            far more than simple caching. Many teams run Redis next to their
+            primary database to absorb read traffic and serve hot data
+            instantly.
+          </p>
+          <p>
+            <strong>Upstash</strong> runs Redis as a serverless database, so
+            there is nothing to provision and no failover to manage. You create
+            a database in seconds, connect over HTTP or the Redis protocol, and
+            pay only for the requests you make. Databases can be replicated
+            across regions for high availability close to your users.
+          </p>
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/src/components/home/product-new/index.tsx
+++ b/src/components/home/product-new/index.tsx
@@ -1,5 +1,6 @@
 import Button from "@/components/button";
 import Container from "@/components/container";
+import CopyButton from "@/components/copy-button";
 import HomeHeroProducts from "@/components/home/hero/hero-products";
 import { HeroTabQStash } from "@/components/home/hero/hero-tab-qstash";
 import { HeroTabRedis } from "@/components/home/hero/hero-tab-redis";
@@ -8,8 +9,12 @@ import { HeroTabWorkflow } from "@/components/home/hero/hero-tab-workflow";
 import cx from "@/utils/cx";
 import { Product } from "@/utils/type";
 import { IconArrowUpRight, IconNotes, IconPlus } from "@tabler/icons-react";
+import Link from "next/link";
 import React, { useState } from "react";
 import { HeroTabBox } from "../hero/hero-tab-box";
+
+const UPSTASH_SKILL_COMMAND =
+  "npx skills add https://github.com/upstash/skills --skill upstash";
 
 const taglines = {
   [Product.REDIS]: {
@@ -53,6 +58,13 @@ const HeroProductTagline = ({ activeProduct }: { activeProduct: Product }) => {
         {title}
       </h2>
       <div className="xs:flex-row flex flex-col justify-center gap-3">
+        {activeProduct === Product.REDIS && (
+          <Link href="/redis">
+            <Button variant={"default"} className="h-[42px] px-5">
+              Learn more
+            </Button>
+          </Link>
+        )}
         <a href={docsLink} target="_blank">
           <Button variant={"defaultDark"} className="h-[42px] px-5">
             Documentation
@@ -78,6 +90,21 @@ const HeroProductTagline = ({ activeProduct }: { activeProduct: Product }) => {
             )}
           </Button>
         </a>
+      </div>
+
+      <div className="mt-3 flex w-full flex-col items-center gap-2">
+        <div className="flex w-fit max-w-full items-center gap-3 overflow-x-auto rounded-xl bg-bg-mute py-2 pl-4 pr-6">
+          <code className="whitespace-nowrap font-mono text-xs text-text md:text-sm">
+            {UPSTASH_SKILL_COMMAND}
+          </code>
+          <CopyButton
+            code={UPSTASH_SKILL_COMMAND}
+            className="shrink-0 text-text-mute hover:text-primary"
+          />
+        </div>
+        <span className="text-xs text-text-mute">
+          Add the Upstash skill to your AI coding agent
+        </span>
       </div>
     </div>
   );

--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,6 @@
 {
   "redirects": [
     {
-      "source": "/redis",
-      "destination": "https://upstash.com/docs/redis"
-    },
-    {
       "source": "/qstash",
       "destination": "https://upstash.com/docs/qstash"
     },


### PR DESCRIPTION
- Add dedicated /redis product landing page (hero, features, use cases, skills, what-is, FAQ, CTA) with FAQPage structured data
- Link to /redis from the homepage Redis product tab and show the Upstash skill install snippet across all product tabs
- Bump /redis sitemap priority to 0.9