### PR TITLE
DX-2724: homepage FAQ section + pricing page crawlability

### DIFF
--- a/data/blog/2026-06-03-redis-vs-valkey.mdx
+++ b/data/blog/2026-06-03-redis-vs-valkey.mdx
@@ -14,14 +14,14 @@ description: "The 2026 Upstash Redis vs. Valkey comparison. The fork, the hostin
 
 ## Quick summary
 
-- **Valkey is a fork of Redis, not a hosted product.** When Redis relicensed away from open source in 2024, the community forked Redis 7.2 into Valkey under the Linux Foundation (BSD-3). To actually *use* it as a service you pick a managed host — the biggest is **AWS ElastiCache for Valkey** — so that's what we compare Upstash against here.
+- **Valkey is a fork of Redis, not a hosted product.** When Redis relicensed away from open source in 2024, the community forked Redis 7.2 into Valkey under the Linux Foundation (BSD-3). To actually *use* it as a service you pick a managed host. The biggest is **AWS ElastiCache for Valkey**, so that's what we compare Upstash against here.
 - **Provisioned vs serverless.** ElastiCache gives you nodes (or a serverless cache) inside a VPC. You choose instance sizes, replicas, and shards, and you pay by the hour whether or not traffic arrives. Upstash has no nodes: you get an endpoint, pay per command, and it scales to zero.
 - **TCP-in-a-VPC vs HTTPS-everywhere.** ElastiCache is reachable over the Redis protocol from inside its VPC. Upstash exposes both the Redis protocol *and* an HTTPS REST endpoint, so the same database works from a Cloudflare Worker, the edge, or a browser.
 - **Pricing shape is the real difference.** ElastiCache for Valkey serverless is **$0.084 per GB-hour of storage + $0.0023 per million ECPUs** ([ElastiCache pricing](https://aws.amazon.com/elasticache/pricing/)). A small node-based cache with a replica runs hundreds of dollars a month, always on. Upstash is **$0.20 per 100K commands** pay-as-you-go, fixed plans from **$10/month**, and a free tier ([Upstash pricing](https://upstash.com/pricing/redis)).
 
 ## What is the difference between Valkey and Redis?
 
-In March 2024, Redis Ltd. [moved Redis from the BSD-3 license to SSPL/RSALv2](https://www.theregister.com/2024/03/22/redis_changes_license/) — no longer open source by the OSI definition. Within days, a group of core contributors and cloud providers (AWS, Google Cloud, Oracle, Ericsson, Snap) forked the last open-source release, Redis 7.2.4, into **Valkey**, and [regrouped under the Linux Foundation](https://www.linuxfoundation.org/press/linux-foundation-launches-open-source-valkey-community) to keep it under BSD-3. Valkey is "the Redis that stayed open."
+In March 2024, Redis Ltd. [moved Redis from the BSD-3 license to SSPL/RSALv2](https://www.theregister.com/2024/03/22/redis_changes_license/), ending its status as open source by the OSI definition. Within days, a group of core contributors and cloud providers (AWS, Google Cloud, Oracle, Ericsson, Snap) forked the last open-source release, Redis 7.2.4, into **Valkey**, and [regrouped under the Linux Foundation](https://www.linuxfoundation.org/press/linux-foundation-launches-open-source-valkey-community) to keep it under BSD-3. Valkey is "the Redis that stayed open."
 
 Two years on, the projects have genuinely diverged but are still ~90% command-compatible:
 
@@ -30,7 +30,7 @@ Two years on, the projects have genuinely diverged but are still ~90% command-co
 
 On raw distribution, Valkey has surpassed **100 million Docker pulls (up 17× year over year)** as of its two-year mark in May 2026. Pulls aren't deployments, but they're the closest thing to a vendor-neutral adoption signal, and the trajectory is steep ([Valkey turns two, AWS](https://aws.amazon.com/blogs/database/valkey-turns-two/)).
 
-The important framing for this post: **Valkey is an engine, Upstash is a service.** Comparing them directly is a category error. The fair comparison is Upstash against a *managed* Valkey — and the one most people reach for is AWS ElastiCache for Valkey.
+The important framing for this post: **Valkey is an engine, Upstash is a service.** Comparing them directly is a category error. The fair comparison is Upstash against a *managed* Valkey, and the one most people reach for is AWS ElastiCache for Valkey.
 
 ## What is ElastiCache for Valkey, and how is it different from Upstash?
 
@@ -97,8 +97,8 @@ The rest of this comparison is really about what falls out of that one differenc
 
 I want to be honest about why there's no single head-to-head benchmark table here like in our [Cloudflare KV comparison](https://upstash.com/blog/upstash-redis-vs-cloudflare-kv): the two don't share an access model, so a fair apples-to-apples run is hard to construct.
 
-- **ElastiCache for Valkey** is reachable over **TCP from inside its VPC**. From an EC2 instance or Lambda in the same region/AZ, a `GET` is a sub-millisecond in-memory hop — about as fast as Redis gets. But you cannot reach it from a Cloudflare Worker, a browser, or a serverless function in another cloud without VPC peering and socket support. Cross-region means you run a second cluster and replicate it yourself (Global Datastore).
-- **Upstash Redis** makes one **HTTPS request to the nearest region** for every operation — a few milliseconds from a co-located client, and consistent reads/writes because there's no central write tier and no cold-region penalty. The same database answers from Workers, Vercel, Lambda, or the browser, and global replication is a checkbox.
+- **ElastiCache for Valkey** is reachable over **TCP from inside its VPC**. From an EC2 instance or Lambda in the same region/AZ, a `GET` is a sub-millisecond in-memory hop, about as fast as Redis gets. But you cannot reach it from a Cloudflare Worker, a browser, or a serverless function in another cloud without VPC peering and socket support. Cross-region means you run a second cluster and replicate it yourself (Global Datastore).
+- **Upstash Redis** makes one **HTTPS request to the nearest region** for every operation: a few milliseconds from a co-located client, and consistent reads/writes because there's no central write tier and no cold-region penalty. The same database answers from Workers, Vercel, Lambda, or the browser, and global replication is a checkbox.
 
 So the latency story is conditional:
 
@@ -109,34 +109,34 @@ So the latency story is conditional:
 | Multi-region reads | **Upstash** | Toggle read regions; ElastiCache needs you to run + replicate clusters |
 | Serverless functions with cold connections | **Upstash** | Stateless HTTPS; no TCP pool to warm against a VPC cache |
 
-If your code lives next to the cache in one AWS region, ElastiCache wins on raw latency. The moment your code is *not* in that VPC — edge, multi-cloud, browser, or just multi-region — Upstash wins by being reachable at all.
+If your code lives next to the cache in one AWS region, ElastiCache wins on raw latency. The moment your code is *not* in that VPC (edge, multi-cloud, browser, or just multi-region), Upstash wins by being reachable at all.
 
 ## What does each one cost?
 
-This is where the two models diverge hardest — and where you can't just compare unit prices. Upstash bills **per command**; ElastiCache for Valkey bills **per GB-hour of capacity plus ECPUs** (or per node-hour). To put them on common footing, normalize to a concrete workload and compute each bill:
+This is where the two models diverge hardest, and where you can't just compare unit prices. Upstash bills **per command**; ElastiCache for Valkey bills **per GB-hour of capacity plus ECPUs** (or per node-hour). To put them on common footing, normalize to a concrete workload and compute each bill:
 
-1. **How much data you store** (GB) — drives ElastiCache's GB-hours and the Upstash storage line.
-2. **How many commands per month** — drives Upstash's per-command cost and ElastiCache's ECPUs.
-3. **Average value size** — the sneaky one. ElastiCache serverless charges **1 ECPU per KB per command**, so a 4 KB value costs 4× the ECPUs of a 1 KB value. Upstash counts the command regardless of size.
+1. **How much data you store** (GB), which drives ElastiCache's GB-hours and the Upstash storage line.
+2. **How many commands per month**, which drives Upstash's per-command cost and ElastiCache's ECPUs.
+3. **Average value size**, the sneaky one. ElastiCache serverless charges **1 ECPU per KB per command**, so a 4 KB value costs 4× the ECPUs of a 1 KB value. Upstash counts the command regardless of size.
 
-The other thing the unit prices hide is the **floor**: ElastiCache serverless meters a minimum (≈$6/month for Valkey at its 100 MB floor; node-based has no scale-to-zero at all — you pay for the node 24/7), while Upstash's free tier and pay-as-you-go scale to **zero**. So the comparison flips on traffic shape: serverless/per-command wins for spiky or low-to-medium traffic, node-based wins for steady high throughput. Published ElastiCache-serverless figures bear this out — a ~4 GB cache lands around [$360/month on serverless vs ~$230/month on on-demand nodes](https://www.dragonflydb.io/guides/what-you-need-to-know-about-elasticache-serverless) (Redis OSS numbers; Valkey runs ~20–33% lower).
+The other thing the unit prices hide is the **floor**: ElastiCache serverless meters a minimum (≈$6/month for Valkey at its 100 MB floor; node-based has no scale-to-zero at all, so you pay for the node 24/7), while Upstash's free tier and pay-as-you-go scale to **zero**. So the comparison flips on traffic shape: serverless/per-command wins for spiky or low-to-medium traffic, node-based wins for steady high throughput. Published ElastiCache-serverless figures bear this out: a ~4 GB cache lands around [$360/month on serverless vs ~$230/month on on-demand nodes](https://www.dragonflydb.io/guides/what-you-need-to-know-about-elasticache-serverless) (Redis OSS numbers; Valkey runs ~20–33% lower).
 
 **ElastiCache for Valkey** charges for capacity you provision, not requests you make:
 
-- *Node-based:* always-on instances billed by the hour. A small `cache.t4g.medium` (3 GiB) is **$0.052/hr (~$38/month)**; a memory-optimized `cache.r7g.xlarge` (26 GiB) is **$0.3496/hr (~$255/month)** ([ElastiCache pricing](https://aws.amazon.com/elasticache/pricing/)). You'll usually run **at least two** (primary + replica) for failover, so double it — and you pay it whether traffic is 0 or 50k rps. (One-/three-year reserved nodes cut this up to ~55% for steady workloads.)
-- *Serverless:* **$0.084 per GB-hour** of stored data (≈**$61/GB-month**, billed continuously from the moment the cache is "Available" until you delete it) plus **$0.0023 per million ECPUs** ([ElastiCache pricing](https://aws.amazon.com/elasticache/pricing/)). Valkey's floor is 100 MB (~$6/month). Note: Global Datastore (cross-region) is **node-based only** — not available on Serverless ([AWS deployment docs](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/WhatIs.deployment.html)).
+- *Node-based:* always-on instances billed by the hour. A small `cache.t4g.medium` (3 GiB) is **$0.052/hr (~$38/month)**; a memory-optimized `cache.r7g.xlarge` (26 GiB) is **$0.3496/hr (~$255/month)** ([ElastiCache pricing](https://aws.amazon.com/elasticache/pricing/)). You'll usually run **at least two** (primary + replica) for failover, so double it, and you pay it whether traffic is 0 or 50k rps. (One-/three-year reserved nodes cut this up to ~55% for steady workloads.)
+- *Serverless:* **$0.084 per GB-hour** of stored data (≈**$61/GB-month**, billed continuously from the moment the cache is "Available" until you delete it) plus **$0.0023 per million ECPUs** ([ElastiCache pricing](https://aws.amazon.com/elasticache/pricing/)). Valkey's floor is 100 MB (~$6/month). Note: Global Datastore (cross-region) is **node-based only**, not available on Serverless ([AWS deployment docs](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/WhatIs.deployment.html)).
 
 **Upstash Redis** charges for what you use ([Upstash pricing](https://upstash.com/pricing/redis)):
 
 - *Pay-as-you-go:* **$0.20 per 100K commands** (reads and writes priced the same) + **$0.25/GB-month** storage; bandwidth free; scales to **zero**.
-- *Fixed plans:* flat monthly, no per-command charge — **250MB $10, 1GB $20, 5GB $100, 10GB $200, 50GB $400, 100GB $800**, each up to 10,000 commands/sec.
+- *Fixed plans:* flat monthly, no per-command charge: **250MB $10, 1GB $20, 5GB $100, 10GB $200, 50GB $400, 100GB $800**, each up to 10,000 commands/sec.
 - *Free tier:* 256 MB and 500K commands/month.
 
-One thing the bare node price hides: **every Upstash paid plan already includes replication and automatic failover** ([Upstash replication docs](https://upstash.com/docs/redis/features/replication)) — multiple replicas, so if one fails another keeps serving. That makes a single $38 `cache.t4g.medium` and a $20 Upstash plan apples-to-oranges: the lone node is a single point of failure. To match the HA you get on the $20 Upstash database you'd run a node *plus a replica* (~$76/month for `t4g.medium`) and still own the failover configuration yourself.
+One thing the bare node price hides: **every Upstash paid plan already includes replication and automatic failover** ([Upstash replication docs](https://upstash.com/docs/redis/features/replication)): multiple replicas, so if one fails another keeps serving. That makes a single $38 `cache.t4g.medium` and a $20 Upstash plan apples-to-oranges: the lone node is a single point of failure. To match the HA you get on the $20 Upstash database you'd run a node *plus a replica* (~$76/month for `t4g.medium`) and still own the failover configuration yourself.
 
 Because the two price on different axes, the only honest comparison is per-workload. Here are three, using the AWS rates above ($0.084/GB-hr, $0.0023/M ECPU, ~1 ECPU per request for values up to 1 KB) against Upstash's published pricing.
 
-**Scenario 1 — spiky traffic + many environments (Upstash wins big)**
+**Scenario 1: spiky traffic + many environments (Upstash wins big)**
 
 An early-stage SaaS: prod does ~5M commands/month (busy by day, near-idle at night), 300 MB hot data, plus a staging and three preview environments that sit idle ~95% of the time.
 
@@ -147,11 +147,11 @@ An early-stage SaaS: prod does ~5M commands/month (busy by day, near-idle at nig
 | 4 idle non-prod envs | ~$0 (no traffic) | floor ~$6 each → ~$24.00 |
 | **Total** | **~$10/mo** | **~$42/mo** |
 
-The prod line barely matters. The gap is that AWS can't idle to zero — every non-prod cache bills 24/7, while Upstash PAYG drops to pennies when traffic stops. The more environments and the burstier the load, the wider the gap.
+The prod line barely matters. The gap is that AWS can't idle to zero: every non-prod cache bills 24/7, while Upstash PAYG drops to pennies when traffic stops. The more environments and the burstier the load, the wider the gap.
 
-**Scenario 2 — steady mid-throughput (Upstash Fixed wins)**
+**Scenario 2: steady mid-throughput (Upstash Fixed wins)**
 
-A production cache at a steady 2,500 req/s with an 8 GB working set, single region — well under the 10K req/s Fixed ceiling.
+A production cache at a steady 2,500 req/s with an 8 GB working set, single region, well under the 10K req/s Fixed ceiling.
 
 | Cost line | Upstash (Fixed 10GB) | ElastiCache for Valkey (Serverless) |
 | --- | --- | --- |
@@ -159,19 +159,19 @@ A production cache at a steady 2,500 req/s with an 8 GB working set, single regi
 | Commands / throughput | included | ~6.57B req → ~$15.11 |
 | **Total** | **$200/mo flat** | **~$506/mo** |
 
-A flat plan wins ~2.5×, and the bill doesn't move with volume. AWS storage alone ($490) is more than twice the entire Upstash bill — a non-trivial working set on per-GB-hour storage is expensive no matter how efficient your access pattern.
+A flat plan wins ~2.5×, and the bill doesn't move with volume. AWS storage alone ($490) is more than twice the entire Upstash bill: a non-trivial working set on per-GB-hour storage is expensive no matter how efficient your access pattern.
 
-**Scenario 3 — ultra-high sustained RPS, all-in on AWS (ElastiCache wins — on fit)**
+**Scenario 3: ultra-high sustained RPS, all-in on AWS (ElastiCache wins on fit)**
 
 40,000 req/s sustained, 25 GB, a team already running Lambda + RDS in the same VPC in us-east-1, with a single-vendor procurement requirement. ElastiCache for Valkey serverless works out to `25 GB × $61 + 105B req × $0.0023/M ≈` **~$1,775/mo**, fully self-serve.
 
-This is genuinely AWS's lane — but on **fit**, not sticker price. At 40K sustained req/s you're past Upstash's self-serve 10K req/s ceiling, so the Upstash side is an enterprise/committed deal, not the list rate, and the comparison becomes a negotiated number. The deciding factors are architectural: same VPC and region, IAM auth, one bill, one vendor for compliance and procurement. The counter-pull even here: Global Datastore is node-based only and there's no HTTP/REST path, so if "high scale" also means *global* or *edge*, the AWS-native advantage narrows fast.
+This is genuinely AWS's lane, though on **fit** rather than sticker price. At 40K sustained req/s you're past Upstash's self-serve 10K req/s ceiling, so the Upstash side is an enterprise/committed deal, not the list rate, and the comparison becomes a negotiated number. The deciding factors are architectural: same VPC and region, IAM auth, one bill, one vendor for compliance and procurement. The counter-pull even here: Global Datastore is node-based only and there's no HTTP/REST path, so if "high scale" also means *global* or *edge*, the AWS-native advantage narrows fast.
 
-**The through-line:** Upstash wins decisively on idle economics (PAYG) and predictable mid-scale (Fixed); ElastiCache wins on single-region ultra-high RPS inside an all-AWS architecture — and even that's a fit/procurement story, not a "can't compete on price" one.
+**The through-line:** Upstash wins decisively on idle economics (PAYG) and predictable mid-scale (Fixed); ElastiCache wins on single-region ultra-high RPS inside an all-AWS architecture, and even that's a fit/procurement story rather than a "can't compete on price" one.
 
 ## Which APIs and data structures does each support?
 
-Both speak Redis, so the data structures are familiar on either side — strings, hashes, lists, sets, sorted sets, streams, bitmaps, HyperLogLog, pub/sub, geospatial, Lua scripting, pipelines, and transactions.
+Both speak Redis, so the data structures are familiar on either side: strings, hashes, lists, sets, sorted sets, streams, bitmaps, HyperLogLog, pub/sub, geospatial, Lua scripting, pipelines, and transactions.
 
 The differences are at the edges:
 
@@ -185,12 +185,12 @@ This is the practical dealbreaker for a lot of teams.
 **ElastiCache for Valkey** runs where your AWS network runs:
 
 - Reachable from EC2, ECS, EKS, and Lambda **inside the same VPC** over the Redis protocol.
-- Reaching it from outside the VPC needs VPC peering, a transit setup, or a bastion — there's no public HTTPS endpoint.
+- Reaching it from outside the VPC needs VPC peering, a transit setup, or a bastion; there's no public HTTPS endpoint.
 - It needs a TCP socket, so environments without raw sockets (Cloudflare Workers, the browser) can't talk to it directly.
 
 **Upstash Redis** runs everywhere a client can make an HTTPS call:
 
-1. The standard **Redis protocol** on port 6379 with TLS — any Redis client (`redis-cli`, `ioredis`, `go-redis`, `jedis`) works.
+1. The standard **Redis protocol** on port 6379 with TLS, so any Redis client (`redis-cli`, `ioredis`, `go-redis`, `jedis`) works.
 2. An **HTTPS REST endpoint**, so Cloudflare Workers, Vercel serverless, AWS Lambda, edge runtimes, and even browsers can use the same database with no socket support.
 
 ### Is it single-region or global?
@@ -199,17 +199,17 @@ Both *can* go multi-region, but the model is different.
 
 **ElastiCache for Valkey** offers [Global Datastore](https://aws.amazon.com/blogs/database/build-a-multi-region-session-store-with-amazon-elasticache-for-valkey-global-datastore/): one primary region replicates to **up to two** secondary regions with sub-second replication, and a secondary can be promoted to primary in under a minute for disaster recovery. But each region is a **full cluster you provision and pay for**, writes only go to the primary region, and secondaries are read-only. Global is something you architect and operate.
 
-**Upstash Redis** makes global a **checkbox**: you toggle read regions on a single database, every region holds the full dataset and answers reads locally, and the SDK gives you read-your-writes across regions. Databases can run in **14 AWS regions and 4 GCP regions**, and you can add **as many read replicas as you like** — there's no two-secondary cap and no per-region cluster to size or wire together ([Upstash global database docs](https://upstash.com/docs/redis/features/globaldatabase)).
+**Upstash Redis** makes global a **checkbox**: you toggle read regions on a single database, every region holds the full dataset and answers reads locally, and the SDK gives you read-your-writes across regions. Databases can run in **14 AWS regions and 4 GCP regions**, and you can add **as many read replicas as you like**, with no two-secondary cap and no per-region cluster to size or wire together ([Upstash global database docs](https://upstash.com/docs/redis/features/globaldatabase)).
 
 ## What about operations?
 
 **ElastiCache** is managed, but it's still infrastructure you make decisions about: instance family and size, number of replicas, cluster mode and shard count, maintenance windows and engine version upgrades, failover behavior, and scaling events that can require resizing. AWS handles the undifferentiated heavy lifting; you still own the topology.
 
-**Upstash** has no topology to own. You create a database, optionally tick read regions, and that's it — no sizing, no patching, no failover configuration, no scaling events. It's the serverless trade: less control, far less to operate.
+**Upstash** has no topology to own. You create a database, optionally tick read regions, and that's it: no sizing, no patching, no failover configuration, no scaling events. It's the serverless trade: less control, far less to operate.
 
 ## What does the code look like?
 
-A rate limiter on Upstash in a Next.js route handler — HTTPS, no socket, no VPC, runs on any host (Vercel, your own Node server, the edge):
+A rate limiter on Upstash in a Next.js route handler (HTTPS, no socket, no VPC, runs on any host like Vercel, your own Node server, or the edge):
 
 ```tsx id="code-upstash-ratelimit"
 // app/api/ping/route.ts
@@ -226,7 +226,7 @@ export async function GET() {
 }
 ```
 
-The equivalent on ElastiCache for Valkey uses a standard Redis client over TCP — the same code you'd write against Redis OSS — but it only works when the Next.js server runs **inside the same VPC** as the cluster (e.g. on ECS/EC2, not a typical serverless deploy):
+The equivalent on ElastiCache for Valkey uses a standard Redis client over TCP (the same code you'd write against Redis OSS), but it only works when the Next.js server runs **inside the same VPC** as the cluster (e.g. on ECS/EC2, not a typical serverless deploy):
 
 ```tsx id="code-valkey-ratelimit"
 // app/api/ping/route.ts
@@ -244,7 +244,7 @@ export async function GET() {
 }
 ```
 
-Both are trivially fine for INCR-heavy workloads — Valkey *is* Redis, so the write-heavy patterns that break a key-value cache work great on either. The difference isn't the code, it's the deployment: the first runs anywhere with nothing to provision; the second needs the app to sit inside a VPC with a network path to a running cluster.
+Both are trivially fine for INCR-heavy workloads. Valkey *is* Redis, so the write-heavy patterns that break a key-value cache work great on either. The code is the same on both; what differs is the deployment: the first runs anywhere with nothing to provision, while the second needs the app to sit inside a VPC with a network path to a running cluster.
 
 ## When should you use ElastiCache for Valkey over Upstash Redis?
 
@@ -257,18 +257,18 @@ Use **ElastiCache for Valkey** when:
 
 Choose **Upstash Redis** when:
 
-- Your code runs at the edge, in serverless functions, across multiple clouds, or in the browser — anywhere outside one VPC.
+- Your code runs at the edge, in serverless functions, across multiple clouds, or in the browser, anywhere outside one VPC.
 - You want global replication and read-your-writes without running and syncing clusters yourself.
 - You don't want to size, patch, fail over, or pay for idle capacity.
 - Your traffic is spiky or low-to-medium and per-request pricing (with a free tier) beats always-on nodes.
 
-Quick note on Upstash: you can create a free Redis database for your AI agents or experiments by sending a POST request to [https://upstash.com/start-redis](https://upstash.com/start-redis). No signup or API key needed — run it in your terminal right now and get a fresh Redis database.
+Quick note on Upstash: you can create a free Redis database for your AI agents or experiments by sending a POST request to [https://upstash.com/start-redis](https://upstash.com/start-redis). No signup or API key needed; run it in your terminal right now and get a fresh Redis database.
 
 ## FAQ
 
 ### Is Valkey the same as Redis?
 
-Almost. Valkey is a fork of the last open-source Redis (7.2), kept open under the Linux Foundation. It's ~90% command-compatible and a near-drop-in replacement, but it doesn't include Redis Ltd.'s proprietary modules, and the two have started to diverge — Valkey on engine performance, Redis on built-in modules.
+Almost. Valkey is a fork of the last open-source Redis (7.2), kept open under the Linux Foundation. It's ~90% command-compatible and a near-drop-in replacement, but it doesn't include Redis Ltd.'s proprietary modules, and the two have started to diverge: Valkey on engine performance, Redis on built-in modules.
 
 ### Why compare Upstash to ElastiCache for Valkey instead of "Valkey"?
 
@@ -284,15 +284,15 @@ It depends where your code runs. From a client in the same VPC/AZ, ElastiCache's
 
 ### Which is cheaper?
 
-For spiky, low-to-medium, or globally distributed traffic, Upstash is usually much cheaper — per-request pricing, a free tier, and scale-to-zero versus always-on nodes (hundreds of dollars/month with a replica) or storage-dominated serverless GB-hours. For large, steady, single-region throughput, a reserved ElastiCache node can win.
+For spiky, low-to-medium, or globally distributed traffic, Upstash is usually much cheaper: per-request pricing, a free tier, and scale-to-zero versus always-on nodes (hundreds of dollars/month with a replica) or storage-dominated serverless GB-hours. For large, steady, single-region throughput, a reserved ElastiCache node can win.
 
 ### Does Valkey support global / multi-region deployment?
 
-Yes, via ElastiCache for Valkey Global Datastore — a primary region replicates to up to two read-only secondary regions, with promotion for disaster recovery. The difference from Upstash is operational: you run and pay for a full cluster in each region and writes stay in the primary region, whereas Upstash makes read regions a toggle on one database with read-your-writes across them.
+Yes, via ElastiCache for Valkey Global Datastore: a primary region replicates to up to two read-only secondary regions, with promotion for disaster recovery. The difference from Upstash is operational: you run and pay for a full cluster in each region and writes stay in the primary region, whereas Upstash makes read regions a toggle on one database with read-your-writes across them.
 
 ### How do you compare the two pricing models?
 
-Pick a workload — GB stored, commands per month, and average value size — then compute each bill. Upstash is per command (plus storage); ElastiCache serverless is GB-hours plus ECPUs (1 ECPU per KB per command), or fixed node-hours. The decision usually comes down to traffic shape: per-command and serverless win for spiky or low-to-medium traffic and scale to zero; node-based clusters win for steady high throughput.
+Pick a workload (GB stored, commands per month, and average value size), then compute each bill. Upstash is per command (plus storage); ElastiCache serverless is GB-hours plus ECPUs (1 ECPU per KB per command), or fixed node-hours. The decision usually comes down to traffic shape: per-command and serverless win for spiky or low-to-medium traffic and scale to zero; node-based clusters win for steady high throughput.
 
 ### Do both support TTLs and the same data structures?
 

--- a/data/blog/2026-06-03-redis-vs-valkey.mdx
+++ b/data/blog/2026-06-03-redis-vs-valkey.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Upstash Redis vs Valkey: Features, Performance & Pricing in 2026"
+title: "Redis vs Valkey: Features, Performance & Pricing in 2026"
 slug: upstash-redis-vs-valkey
 authors: [arda]
 tags: [redis]

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@
 import "../styles/home.css";
 import { ParsedUrlQueryInput } from "querystring";
 import HomeCommunity from "@/components/home/community";
+import HomeFaq from "@/components/home/faq";
 import HomeFast from "@/components/home/fast";
 import HomeHero from "@/components/home/hero";
 import HomeHeroCustomer from "@/components/home/hero/hero-customer";
@@ -28,6 +29,7 @@ export default function Home({
       <HomeHeroCustomer />
       {/* TODO: Enterprise */}
       <HomeCommunity />
+      <HomeFaq />
     </main>
   );
 }

--- a/src/app/pricing/box/layout.tsx
+++ b/src/app/pricing/box/layout.tsx
@@ -1,3 +1,4 @@
+import SeoPlanData from "@/components/pricing/box/seo-plan-data";
 import { Metadata } from "next";
 import { ReactNode } from "react";
 
@@ -10,6 +11,9 @@ export const metadata: Metadata = {
   description,
   alternates: {
     canonical: "/pricing/box",
+    types: {
+      "text/markdown": "/pricing/box.md",
+    },
   },
   openGraph: {
     type: "website",
@@ -29,5 +33,10 @@ export default function PricingBoxLayout({
 }: {
   children: ReactNode;
 }) {
-  return <>{children}</>;
+  return (
+    <>
+      {children}
+      <SeoPlanData />
+    </>
+  );
 }

--- a/src/app/pricing/qstash/layout.tsx
+++ b/src/app/pricing/qstash/layout.tsx
@@ -1,3 +1,4 @@
+import SeoPlanData from "@/components/pricing/qstash/seo-plan-data";
 import { Metadata } from "next";
 import { ReactNode } from "react";
 
@@ -10,6 +11,9 @@ export const metadata: Metadata = {
   description,
   alternates: {
     canonical: "/pricing/qstash",
+    types: {
+      "text/markdown": "/pricing/qstash.md",
+    },
   },
   openGraph: {
     type: "website",
@@ -29,5 +33,10 @@ export default function PricingQStashLayout({
 }: {
   children: ReactNode;
 }) {
-  return <>{children}</>;
+  return (
+    <>
+      {children}
+      <SeoPlanData />
+    </>
+  );
 }

--- a/src/app/pricing/redis/layout.tsx
+++ b/src/app/pricing/redis/layout.tsx
@@ -1,3 +1,4 @@
+import SeoPlanData from "@/components/pricing/redis/seo-plan-data";
 import { Metadata } from "next";
 import { ReactNode } from "react";
 
@@ -10,6 +11,9 @@ export const metadata: Metadata = {
   description,
   alternates: {
     canonical: "/pricing/redis",
+    types: {
+      "text/markdown": "/pricing/redis.md",
+    },
   },
   openGraph: {
     type: "website",
@@ -29,5 +33,10 @@ export default function PricingRedisLayout({
 }: {
   children: ReactNode;
 }) {
-  return <>{children}</>;
+  return (
+    <>
+      {children}
+      <SeoPlanData />
+    </>
+  );
 }

--- a/src/app/pricing/search/layout.tsx
+++ b/src/app/pricing/search/layout.tsx
@@ -1,3 +1,4 @@
+import SeoPlanData from "@/components/pricing/search/seo-plan-data";
 import { Metadata } from "next";
 import { ReactNode } from "react";
 
@@ -10,6 +11,9 @@ export const metadata: Metadata = {
   description,
   alternates: {
     canonical: "/pricing/search",
+    types: {
+      "text/markdown": "/pricing/search.md",
+    },
   },
   openGraph: {
     type: "website",
@@ -29,5 +33,10 @@ export default function PricingSearchLayout({
 }: {
   children: ReactNode;
 }) {
-  return <>{children}</>;
+  return (
+    <>
+      {children}
+      <SeoPlanData />
+    </>
+  );
 }

--- a/src/app/pricing/vector/layout.tsx
+++ b/src/app/pricing/vector/layout.tsx
@@ -1,3 +1,4 @@
+import SeoPlanData from "@/components/pricing/vector/seo-plan-data";
 import { Metadata } from "next";
 import { ReactNode } from "react";
 
@@ -10,6 +11,9 @@ export const metadata: Metadata = {
   description,
   alternates: {
     canonical: "/pricing/vector",
+    types: {
+      "text/markdown": "/pricing/vector.md",
+    },
   },
   openGraph: {
     type: "website",
@@ -29,5 +33,10 @@ export default function PricingVectorLayout({
 }: {
   children: ReactNode;
 }) {
-  return <>{children}</>;
+  return (
+    <>
+      {children}
+      <SeoPlanData />
+    </>
+  );
 }

--- a/src/app/pricing/workflow/layout.tsx
+++ b/src/app/pricing/workflow/layout.tsx
@@ -1,3 +1,4 @@
+import SeoPlanData from "@/components/pricing/workflow/seo-plan-data";
 import { Metadata } from "next";
 import { ReactNode } from "react";
 
@@ -10,6 +11,9 @@ export const metadata: Metadata = {
   description,
   alternates: {
     canonical: "/pricing/workflow",
+    types: {
+      "text/markdown": "/pricing/workflow.md",
+    },
   },
   openGraph: {
     type: "website",
@@ -29,5 +33,10 @@ export default function PricingWorkflowLayout({
 }: {
   children: ReactNode;
 }) {
-  return <>{children}</>;
+  return (
+    <>
+      {children}
+      <SeoPlanData />
+    </>
+  );
 }

--- a/src/app/redis/section-faq.tsx
+++ b/src/app/redis/section-faq.tsx
@@ -1,5 +1,6 @@
 import Bg from "@/components/bg";
 import Container from "@/components/container";
+import FaqAccordion from "@/components/faq-accordion";
 import PageHeaderTitle from "@/components/page-header-title";
 
 export default function SectionFaq({
@@ -16,15 +17,8 @@ export default function SectionFaq({
           Frequently asked questions
         </PageHeaderTitle>
 
-        <div className="mt-10 divide-y divide-bg-mute md:mt-14">
-          {items.map(({ question, answer }, index) => (
-            <div key={index} className="py-6">
-              <h3 className="font-display text-lg font-semibold md:text-xl">
-                {question}
-              </h3>
-              <p className="mt-2 text-text-mute">{answer}</p>
-            </div>
-          ))}
+        <div className="mt-10 md:mt-14">
+          <FaqAccordion items={items} />
         </div>
       </Container>
     </section>

--- a/src/components/faq-accordion.tsx
+++ b/src/components/faq-accordion.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import {
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/pricing/accordion";
+import * as Accordion from "@radix-ui/react-accordion";
+
+/**
+ * Expandable FAQ list using the shared pricing accordion. The accordion's
+ * `forceMount` keeps every answer in the server HTML (crawlable) even while
+ * collapsed, matching the FAQPage structured data.
+ */
+export default function FaqAccordion({
+  items,
+}: {
+  items: { question: string; answer: string }[];
+}) {
+  return (
+    <Accordion.Root className="faq" type="single" collapsible>
+      {items.map(({ question, answer }, index) => (
+        <AccordionItem key={index} value={`item-${index}`}>
+          <AccordionTrigger>{question}</AccordionTrigger>
+          <AccordionContent>{answer}</AccordionContent>
+        </AccordionItem>
+      ))}
+    </Accordion.Root>
+  );
+}

--- a/src/components/home/faq/faq-data.ts
+++ b/src/components/home/faq/faq-data.ts
@@ -1,0 +1,35 @@
+// Answers are kept short and direct so each Q&A is eligible for a featured
+// snippet, and the same array feeds both the visible section and the
+// FAQPage structured data.
+export const HOME_FAQ = [
+  {
+    question: "What is Upstash?",
+    answer:
+      "Upstash is a serverless data platform. It provides fully managed Redis, Vector, Search, QStash messaging, Workflow, and Box sandboxes, all with per-request pricing and no servers to provision. You create a database in seconds and connect over HTTP or native protocols from any runtime.",
+  },
+  {
+    question: "Is Upstash free to use?",
+    answer:
+      "Yes. Every Upstash product has a free tier for prototypes and small workloads, with no credit card required to start. You can move to pay-as-you-go or fixed monthly plans as your usage grows.",
+  },
+  {
+    question: "What products does Upstash offer?",
+    answer:
+      "Upstash offers serverless Redis, Vector for embeddings and similarity search, Search for full-text and hybrid search, QStash for messaging and scheduling, Workflow for durable serverless functions, and Box for sandboxed cloud containers that run AI agents and code.",
+  },
+  {
+    question: "How is Upstash priced?",
+    answer:
+      "Upstash uses pay-as-you-go pricing, so you pay per request instead of for always-on servers. Each product also offers fixed monthly plans with predictable costs, plus a free tier to get started.",
+  },
+  {
+    question: "Is Upstash Redis compatible with Redis?",
+    answer:
+      "Yes. Upstash Redis is API-compatible with Redis and works with standard Redis clients over the Redis protocol, as well as a built-in HTTP REST API that works from serverless and edge runtimes without connection pooling.",
+  },
+  {
+    question: "Where does Upstash run?",
+    answer:
+      "Upstash runs globally across multiple regions with optional multi-region replication, so you can keep data close to your users for low latency. The HTTP APIs make it a natural fit for serverless and edge platforms.",
+  },
+];

--- a/src/components/home/faq/index.tsx
+++ b/src/components/home/faq/index.tsx
@@ -1,31 +1,17 @@
-import Bg from "@/components/bg";
-import Container from "@/components/container";
-import FaqAccordion from "@/components/faq-accordion";
 import { HOME_FAQ } from "@/components/home/faq/faq-data";
-import PageHeaderTitle from "@/components/page-header-title";
 import { generateFaqSchema } from "@/utils/structured-schema-generators";
 
+/**
+ * The visible home-page FAQ section was removed, but the FAQPage structured
+ * data is kept for SEO. This component only emits the JSON-LD script.
+ */
 export default function HomeFaq() {
   const faqSchema = generateFaqSchema({ faq: HOME_FAQ });
 
   return (
-    <section className="relative py-10 md:py-20">
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: faqSchema }}
-      />
-
-      <Bg className="top-32 h-1/2" />
-
-      <Container className="max-w-screen-md text-left">
-        <PageHeaderTitle as="h2" className="text-center">
-          Frequently asked questions
-        </PageHeaderTitle>
-
-        <div className="mt-10 md:mt-14">
-          <FaqAccordion items={HOME_FAQ} />
-        </div>
-      </Container>
-    </section>
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: faqSchema }}
+    />
   );
 }

--- a/src/components/home/faq/index.tsx
+++ b/src/components/home/faq/index.tsx
@@ -1,0 +1,37 @@
+import Bg from "@/components/bg";
+import Container from "@/components/container";
+import { HOME_FAQ } from "@/components/home/faq/faq-data";
+import PageHeaderTitle from "@/components/page-header-title";
+import { generateFaqSchema } from "@/utils/structured-schema-generators";
+
+export default function HomeFaq() {
+  const faqSchema = generateFaqSchema({ faq: HOME_FAQ });
+
+  return (
+    <section className="relative py-10 md:py-20">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: faqSchema }}
+      />
+
+      <Bg className="top-32 h-1/2" />
+
+      <Container className="max-w-screen-md text-left">
+        <PageHeaderTitle as="h2" className="text-center">
+          Frequently asked questions
+        </PageHeaderTitle>
+
+        <div className="mt-10 divide-y divide-bg-mute md:mt-14">
+          {HOME_FAQ.map(({ question, answer }, index) => (
+            <div key={index} className="py-6">
+              <h3 className="font-display text-lg font-semibold md:text-xl">
+                {question}
+              </h3>
+              <p className="mt-2 text-text-mute">{answer}</p>
+            </div>
+          ))}
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/src/components/home/faq/index.tsx
+++ b/src/components/home/faq/index.tsx
@@ -1,5 +1,6 @@
 import Bg from "@/components/bg";
 import Container from "@/components/container";
+import FaqAccordion from "@/components/faq-accordion";
 import { HOME_FAQ } from "@/components/home/faq/faq-data";
 import PageHeaderTitle from "@/components/page-header-title";
 import { generateFaqSchema } from "@/utils/structured-schema-generators";
@@ -21,15 +22,8 @@ export default function HomeFaq() {
           Frequently asked questions
         </PageHeaderTitle>
 
-        <div className="mt-10 divide-y divide-bg-mute md:mt-14">
-          {HOME_FAQ.map(({ question, answer }, index) => (
-            <div key={index} className="py-6">
-              <h3 className="font-display text-lg font-semibold md:text-xl">
-                {question}
-              </h3>
-              <p className="mt-2 text-text-mute">{answer}</p>
-            </div>
-          ))}
+        <div className="mt-10 md:mt-14">
+          <FaqAccordion items={HOME_FAQ} />
         </div>
       </Container>
     </section>

--- a/src/components/post/related-redis.tsx
+++ b/src/components/post/related-redis.tsx
@@ -22,7 +22,7 @@ export default function RelatedRedis() {
           Looking for a managed Redis database?
         </span>
         <span className="mt-1 block text-text-mute">
-          Upstash runs Redis as a serverless database — create one in seconds and
+          Upstash runs Redis as a serverless database - create one in seconds and
           pay only per request. Explore Upstash Redis →
         </span>
       </span>

--- a/src/components/pricing/accordion.tsx
+++ b/src/components/pricing/accordion.tsx
@@ -74,18 +74,22 @@ const AccordionContent = React.forwardRef(
     const { children, className } = props;
 
     return (
+      // forceMount keeps the answer in the DOM (and server HTML) even while
+      // collapsed, so crawlers index it and it matches the FAQPage structured
+      // data. The grid-rows trick animates height without unmounting content.
       <Accordion.Content
+        forceMount
         className={cx(
-          "faq-body",
-          "data-[state=open]:animate-slideDown",
-          "data-[state=closed]:animate-slideUp",
-          "overflow-hidden",
+          "faq-body grid overflow-hidden transition-all duration-300 ease-out",
+          "data-[state=closed]:grid-rows-[0fr] data-[state=open]:grid-rows-[1fr]",
           className,
         )}
         {...props}
         ref={forwardedRef}
       >
-        <span className="block space-y-4 px-6 pb-6">{children}</span>
+        <span className="block min-h-0 overflow-hidden">
+          <span className="block space-y-4 px-6 pb-6">{children}</span>
+        </span>
       </Accordion.Content>
     );
   },

--- a/src/components/pricing/box/seo-plan-data.tsx
+++ b/src/components/pricing/box/seo-plan-data.tsx
@@ -1,0 +1,108 @@
+import { BOX_ALL_PLANS, BOX_PAYG_PLAN, BOX_SIZES } from "@/data/pricing/box";
+
+/**
+ * Crawlable, screen-reader-only mirror of the full pricing data.
+ *
+ * The interactive pricing components only render the plan/size the user has
+ * selected from the dropdown, so the other tiers and sizes never reach the
+ * HTML. This block renders every plan and box size server-side from the same
+ * data source, so search engines and AI crawlers that fetch the page as HTML
+ * (without the Accept header that would route them to /pricing/box.md) still
+ * get the complete pricing. It mirrors data the user can reach via the
+ * dropdown, so it is not hidden/deceptive content.
+ */
+export default function SeoPlanData() {
+  return (
+    <section className="sr-only">
+      <h2>Upstash Box pricing — all plans</h2>
+
+      <table>
+        <caption>Plan overview</caption>
+        <thead>
+          <tr>
+            <th>Plan</th>
+            <th>Price</th>
+            <th>Concurrent boxes</th>
+            <th>CPU hours/month</th>
+            <th>LLM budget/month</th>
+          </tr>
+        </thead>
+        <tbody>
+          {BOX_ALL_PLANS.map((plan) => (
+            <tr key={plan.id}>
+              <td>{plan.name}</td>
+              <td>
+                {plan.priceDisplay}
+                {plan.priceSubtext !== "-" ? ` ${plan.priceSubtext}` : ""}
+              </td>
+              <td>
+                {typeof plan.maxConcurrentBoxes === "number"
+                  ? plan.maxConcurrentBoxes.toLocaleString()
+                  : plan.maxConcurrentBoxes}
+              </td>
+              <td>
+                {typeof plan.cpuHoursPerMonth === "number"
+                  ? plan.cpuHoursPerMonth.toLocaleString()
+                  : plan.cpuHoursPerMonth}
+              </td>
+              <td>{plan.llmBudgetPerMonth}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <table>
+        <caption>Box sizes (Pay as You Go) — all sizes</caption>
+        <thead>
+          <tr>
+            <th>Size</th>
+            <th>vCPU</th>
+            <th>Memory</th>
+            <th>Disk</th>
+            <th>Usage price</th>
+            <th>Keep-alive price</th>
+          </tr>
+        </thead>
+        <tbody>
+          {BOX_SIZES.map((size) => (
+            <tr key={size.id}>
+              <td>{size.label}</td>
+              <td>{size.cpu}</td>
+              <td>{size.memory}</td>
+              <td>{size.storage}</td>
+              <td>${size.cpuHourPrice}/active CPU hour</td>
+              <td>${size.keepAlivePrice}/month</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <h3>Pay as You Go — pricing details</h3>
+      <ul>
+        <li>Price: {BOX_PAYG_PLAN.priceDisplay} {BOX_PAYG_PLAN.priceSubtext}</li>
+        <li>
+          Concurrent boxes:{" "}
+          {typeof BOX_PAYG_PLAN.maxConcurrentBoxes === "number"
+            ? BOX_PAYG_PLAN.maxConcurrentBoxes.toLocaleString()
+            : BOX_PAYG_PLAN.maxConcurrentBoxes}
+        </li>
+        <li>CPU hours/month: {BOX_PAYG_PLAN.cpuHoursPerMonth}</li>
+        <li>LLM budget/month: {BOX_PAYG_PLAN.llmBudgetPerMonth}</li>
+        {BOX_PAYG_PLAN.storagePrice !== null ? (
+          <li>Storage: {BOX_PAYG_PLAN.storagePrice}</li>
+        ) : null}
+        {BOX_PAYG_PLAN.cpuHourPricing !== null ? (
+          <li>CPU hour pricing: {BOX_PAYG_PLAN.cpuHourPricing}</li>
+        ) : null}
+        {BOX_PAYG_PLAN.keepAlivePricing !== null ? (
+          <li>Keep-alive pricing: {BOX_PAYG_PLAN.keepAlivePricing}</li>
+        ) : null}
+      </ul>
+
+      <p>
+        Full machine-readable pricing is available at{" "}
+        <a href="/pricing/box.md">/pricing/box.md</a>.
+      </p>
+    </section>
+  );
+}

--- a/src/components/pricing/qstash/seo-plan-data.tsx
+++ b/src/components/pricing/qstash/seo-plan-data.tsx
@@ -1,0 +1,123 @@
+import {
+  QSTASH_ALL_PLANS,
+  QSTASH_FIXED_PLANS,
+  QSTASH_PAYG_PLAN,
+  type QStashPlan,
+} from "@/data/pricing/qstash";
+
+/**
+ * Crawlable, screen-reader-only mirror of the full pricing data.
+ *
+ * The interactive PricingTable / CompareTable only render the plan the user
+ * has selected from the dropdown, so the other tiers never reach the HTML.
+ * This block renders every tier server-side from the same data source, so
+ * search engines and AI crawlers that fetch the page as HTML (without the
+ * Accept header that would route them to /pricing/qstash.md) still get the
+ * complete pricing. It mirrors data the user can reach via the dropdown, so
+ * it is not hidden/deceptive content.
+ */
+function summaryPrice(plan: QStashPlan): string {
+  if (plan.type === "payg") return "$1 per 100K messages";
+  if (plan.monthlyPrice !== null) return `$${plan.monthlyPrice}/month`;
+  return "Custom";
+}
+
+export default function SeoPlanData() {
+  return (
+    <section className="sr-only">
+      <h2>Upstash QStash pricing — all plans</h2>
+
+      <table>
+        <caption>Plan overview</caption>
+        <thead>
+          <tr>
+            <th>Plan</th>
+            <th>Price</th>
+            <th>Max messages/day</th>
+            <th>Max bandwidth</th>
+            <th>Max message size</th>
+          </tr>
+        </thead>
+        <tbody>
+          {QSTASH_ALL_PLANS.map((plan) => (
+            <tr key={plan.id}>
+              <td>{plan.name}</td>
+              <td>{summaryPrice(plan)}</td>
+              <td>{plan.maxMessagesPerDay}</td>
+              <td>{plan.maxBandwidth}</td>
+              <td>{plan.maxMessageSize}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <table>
+        <caption>Fixed plans — all tiers</caption>
+        <thead>
+          <tr>
+            <th>Tier</th>
+            <th>Monthly price</th>
+            <th>Messages/day</th>
+            <th>Bandwidth</th>
+            <th>Max message size</th>
+            <th>Max delay</th>
+            <th>DLQ retention</th>
+            <th>Max parallelism</th>
+          </tr>
+        </thead>
+        <tbody>
+          {QSTASH_FIXED_PLANS.map((plan) => (
+            <tr key={plan.id}>
+              <td>{plan.name}</td>
+              <td>${plan.monthlyPrice}/month</td>
+              <td>{plan.maxMessagesPerDay}</td>
+              <td>{plan.maxBandwidth}</td>
+              <td>{plan.maxMessageSize}</td>
+              <td>{plan.maxDelay}</td>
+              <td>{plan.maxDlqRetention}</td>
+              <td>
+                {typeof plan.maxParallelism === "number"
+                  ? plan.maxParallelism.toLocaleString()
+                  : plan.maxParallelism}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <h3>Pay as You Go — pricing details</h3>
+      <ul>
+        <li>Messages: {QSTASH_PAYG_PLAN.messagePrice}</li>
+        <li>Bandwidth: {QSTASH_PAYG_PLAN.bandwidthPrice}</li>
+        <li>Max messages/day: {QSTASH_PAYG_PLAN.maxMessagesPerDay}</li>
+        <li>Max message size: {QSTASH_PAYG_PLAN.maxMessageSize}</li>
+        <li>Max delay: {QSTASH_PAYG_PLAN.maxDelay}</li>
+        <li>
+          Max HTTP response duration:{" "}
+          {QSTASH_PAYG_PLAN.maxHttpResponseDuration}
+        </li>
+        <li>DLQ retention: {QSTASH_PAYG_PLAN.maxDlqRetention}</li>
+        <li>
+          Active schedules:{" "}
+          {typeof QSTASH_PAYG_PLAN.maxSchedules === "number"
+            ? QSTASH_PAYG_PLAN.maxSchedules.toLocaleString()
+            : QSTASH_PAYG_PLAN.maxSchedules}
+          {QSTASH_PAYG_PLAN.maxSchedulesNote !== null
+            ? ` (${QSTASH_PAYG_PLAN.maxSchedulesNote})`
+            : ""}
+        </li>
+        <li>
+          Max parallelism:{" "}
+          {typeof QSTASH_PAYG_PLAN.maxParallelism === "number"
+            ? QSTASH_PAYG_PLAN.maxParallelism.toLocaleString()
+            : QSTASH_PAYG_PLAN.maxParallelism}
+        </li>
+      </ul>
+
+      <p>
+        Full machine-readable pricing is available at{" "}
+        <a href="/pricing/qstash.md">/pricing/qstash.md</a>.
+      </p>
+    </section>
+  );
+}

--- a/src/components/pricing/redis/seo-plan-data.tsx
+++ b/src/components/pricing/redis/seo-plan-data.tsx
@@ -1,0 +1,109 @@
+import {
+  REDIS_ALL_PLANS,
+  REDIS_FIXED_PLANS,
+  REDIS_PAYG_PLAN,
+  type RedisPlan,
+} from "@/data/pricing/redis";
+
+/**
+ * Crawlable, screen-reader-only mirror of the full pricing data.
+ *
+ * The interactive PricingTable / CompareTable only render the plan the user
+ * has selected from the dropdown, so the other tiers never reach the HTML.
+ * This block renders every tier server-side from the same data source, so
+ * search engines and AI crawlers that fetch the page as HTML (without the
+ * Accept header that would route them to /pricing/redis.md) still get the
+ * complete pricing. It mirrors data the user can reach via the dropdown, so
+ * it is not hidden/deceptive content.
+ */
+function summaryPrice(plan: RedisPlan): string {
+  if (plan.type === "payg") return "$0.20 per 100K commands";
+  if (plan.monthlyPrice !== null) return `$${plan.monthlyPrice}/month`;
+  return "Custom";
+}
+
+export default function SeoPlanData() {
+  return (
+    <section className="sr-only">
+      <h2>Upstash Redis pricing — all plans</h2>
+
+      <table>
+        <caption>Plan overview</caption>
+        <thead>
+          <tr>
+            <th>Plan</th>
+            <th>Price</th>
+            <th>Read region</th>
+            <th>Max data</th>
+            <th>Max bandwidth</th>
+          </tr>
+        </thead>
+        <tbody>
+          {REDIS_ALL_PLANS.map((plan) => (
+            <tr key={plan.id}>
+              <td>{plan.name}</td>
+              <td>{summaryPrice(plan)}</td>
+              <td>
+                {plan.readRegionPrice !== null
+                  ? `+$${plan.readRegionPrice}/region`
+                  : "-"}
+              </td>
+              <td>{plan.dataSize}</td>
+              <td>{plan.maxBandwidth}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <table>
+        <caption>Fixed plans — all tiers</caption>
+        <thead>
+          <tr>
+            <th>Tier</th>
+            <th>Monthly price</th>
+            <th>Per read region</th>
+            <th>Max data</th>
+            <th>Max bandwidth</th>
+            <th>Max commands/sec</th>
+            <th>Max request size</th>
+            <th>Max record size</th>
+          </tr>
+        </thead>
+        <tbody>
+          {REDIS_FIXED_PLANS.map((plan) => (
+            <tr key={plan.id}>
+              <td>{plan.name}</td>
+              <td>${plan.monthlyPrice}/month</td>
+              <td>+${plan.readRegionPrice}/region</td>
+              <td>{plan.dataSize}</td>
+              <td>{plan.maxBandwidth}</td>
+              <td>
+                {typeof plan.maxCommandsPerSec === "number"
+                  ? plan.maxCommandsPerSec.toLocaleString()
+                  : plan.maxCommandsPerSec}
+              </td>
+              <td>{plan.maxRequestSize}</td>
+              <td>{plan.maxRecordSize}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <h3>Pay as You Go — pricing details</h3>
+      <ul>
+        <li>Commands: {REDIS_PAYG_PLAN.requestPrice}</li>
+        <li>Storage: {REDIS_PAYG_PLAN.storagePrice}</li>
+        <li>Bandwidth: {REDIS_PAYG_PLAN.bandwidthPrice}</li>
+        <li>Max data size: {REDIS_PAYG_PLAN.dataSize}</li>
+        <li>Max request size: {REDIS_PAYG_PLAN.maxRequestSize}</li>
+        <li>Max record size: {REDIS_PAYG_PLAN.maxRecordSize}</li>
+        <li>Platforms: {REDIS_PAYG_PLAN.platforms.join(", ")}</li>
+      </ul>
+
+      <p>
+        Full machine-readable pricing is available at{" "}
+        <a href="/pricing/redis.md">/pricing/redis.md</a>.
+      </p>
+    </section>
+  );
+}

--- a/src/components/pricing/search/seo-plan-data.tsx
+++ b/src/components/pricing/search/seo-plan-data.tsx
@@ -1,0 +1,67 @@
+import {
+  SEARCH_ALL_PLANS,
+  SEARCH_PAYG_PLAN,
+  type SearchPlan,
+} from "@/data/pricing/search";
+
+/**
+ * Crawlable, screen-reader-only mirror of the full pricing data.
+ *
+ * The interactive pricing component only renders the plan the user has
+ * selected from the dropdown, so the other plans never reach the HTML.
+ * This block renders every plan server-side from the same data source, so
+ * search engines and AI crawlers that fetch the page as HTML (without the
+ * Accept header that would route them to /pricing/search.md) still get the
+ * complete pricing. It mirrors data the user can reach via the dropdown, so
+ * it is not hidden/deceptive content.
+ */
+function summaryPrice(plan: SearchPlan): string {
+  return plan.priceSubtext && plan.priceSubtext !== "-"
+    ? `${plan.priceDisplay} ${plan.priceSubtext}`
+    : plan.priceDisplay;
+}
+
+export default function SeoPlanData() {
+  return (
+    <section className="sr-only">
+      <h2>Upstash Search pricing — all plans</h2>
+
+      <table>
+        <caption>Plan overview</caption>
+        <thead>
+          <tr>
+            <th>Plan</th>
+            <th>Price</th>
+            <th>Monthly queries</th>
+            <th>Max records</th>
+          </tr>
+        </thead>
+        <tbody>
+          {SEARCH_ALL_PLANS.map((plan) => (
+            <tr key={plan.id}>
+              <td>{plan.name}</td>
+              <td>{summaryPrice(plan)}</td>
+              <td>{plan.monthlyQueryLimit}</td>
+              <td>{plan.maxRecords}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <h3>Pay as You Go — pricing details</h3>
+      <ul>
+        <li>Price: {summaryPrice(SEARCH_PAYG_PLAN)}</li>
+        {SEARCH_PAYG_PLAN.requestPrice !== null && (
+          <li>Request price: {SEARCH_PAYG_PLAN.requestPrice}</li>
+        )}
+        <li>Monthly query limit: {SEARCH_PAYG_PLAN.monthlyQueryLimit}</li>
+        <li>Max records: {SEARCH_PAYG_PLAN.maxRecords}</li>
+      </ul>
+
+      <p>
+        Full machine-readable pricing is available at{" "}
+        <a href="/pricing/search.md">/pricing/search.md</a>.
+      </p>
+    </section>
+  );
+}

--- a/src/components/pricing/vector/seo-plan-data.tsx
+++ b/src/components/pricing/vector/seo-plan-data.tsx
@@ -1,0 +1,90 @@
+import {
+  VECTOR_ALL_PLANS,
+  VECTOR_PAYG_PLAN,
+  type VectorPlan,
+} from "@/data/pricing/vector";
+
+/**
+ * Crawlable, screen-reader-only mirror of the full pricing data.
+ *
+ * The interactive PricingTable / CompareTable only render the plan the user
+ * has selected from the dropdown, so the other tiers never reach the HTML.
+ * This block renders every tier server-side from the same data source, so
+ * search engines and AI crawlers that fetch the page as HTML (without the
+ * Accept header that would route them to /pricing/vector.md) still get the
+ * complete pricing. It mirrors data the user can reach via the dropdown, so
+ * it is not hidden/deceptive content.
+ */
+function summaryPrice(plan: VectorPlan): string {
+  return plan.priceSubtext
+    ? `${plan.priceDisplay} ${plan.priceSubtext}`
+    : plan.priceDisplay;
+}
+
+export default function SeoPlanData() {
+  return (
+    <section className="sr-only">
+      <h2>Upstash Vector pricing — all plans</h2>
+
+      <table>
+        <caption>Plan overview</caption>
+        <thead>
+          <tr>
+            <th>Plan</th>
+            <th>Price</th>
+            <th>Max vectors × dimensions</th>
+            <th>Max dimensions</th>
+            <th>Max namespaces</th>
+            <th>Daily query limit</th>
+            <th>Max total data</th>
+            <th>Uptime SLA</th>
+          </tr>
+        </thead>
+        <tbody>
+          {VECTOR_ALL_PLANS.map((plan) => (
+            <tr key={plan.id}>
+              <td>{plan.name}</td>
+              <td>{summaryPrice(plan)}</td>
+              <td>{plan.maxVectorsDimensions}</td>
+              <td>
+                {typeof plan.maxDimensions === "number"
+                  ? plan.maxDimensions.toLocaleString()
+                  : plan.maxDimensions}
+              </td>
+              <td>
+                {typeof plan.maxNamespaces === "number"
+                  ? plan.maxNamespaces.toLocaleString()
+                  : plan.maxNamespaces}
+              </td>
+              <td>{plan.dailyQueryLimit}</td>
+              <td>{plan.maxTotalDataSize}</td>
+              <td>{plan.uptimeSLA}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <h3>Pay as You Go — pricing details</h3>
+      <ul>
+        {VECTOR_PAYG_PLAN.requestPrice !== null && (
+          <li>Requests: {VECTOR_PAYG_PLAN.requestPrice}</li>
+        )}
+        {VECTOR_PAYG_PLAN.storagePrice !== null && (
+          <li>Storage: {VECTOR_PAYG_PLAN.storagePrice}</li>
+        )}
+        {VECTOR_PAYG_PLAN.bandwidthPrice !== null && (
+          <li>Bandwidth: {VECTOR_PAYG_PLAN.bandwidthPrice}</li>
+        )}
+        <li>Max total data size: {VECTOR_PAYG_PLAN.maxTotalDataSize}</li>
+        <li>Max metadata per vector: {VECTOR_PAYG_PLAN.maxMetadataPerVector}</li>
+        <li>Max data per vector: {VECTOR_PAYG_PLAN.maxDataPerVector}</li>
+        <li>SDKs: {VECTOR_PAYG_PLAN.sdks.join(", ")}</li>
+      </ul>
+
+      <p>
+        Full machine-readable pricing is available at{" "}
+        <a href="/pricing/vector.md">/pricing/vector.md</a>.
+      </p>
+    </section>
+  );
+}

--- a/src/components/pricing/workflow/seo-plan-data.tsx
+++ b/src/components/pricing/workflow/seo-plan-data.tsx
@@ -1,0 +1,131 @@
+import {
+  WORKFLOW_ALL_PLANS,
+  WORKFLOW_FIXED_PLANS,
+  WORKFLOW_PAYG_PLAN,
+  type WorkflowPlan,
+} from "@/data/pricing/workflow";
+
+/**
+ * Crawlable, screen-reader-only mirror of the full pricing data.
+ *
+ * The interactive PricingTable / CompareTable only render the plan the user
+ * has selected from the dropdown, so the other tiers never reach the HTML.
+ * This block renders every tier server-side from the same data source, so
+ * search engines and AI crawlers that fetch the page as HTML (without the
+ * Accept header that would route them to /pricing/workflow.md) still get the
+ * complete pricing. It mirrors data the user can reach via the dropdown, so
+ * it is not hidden/deceptive content.
+ */
+function summaryPrice(plan: WorkflowPlan): string {
+  if (plan.type === "payg") return "$1 per 100K steps";
+  if (plan.monthlyPrice !== null) return `$${plan.monthlyPrice}/month`;
+  return "Custom";
+}
+
+export default function SeoPlanData() {
+  return (
+    <section className="sr-only">
+      <h2>Upstash Workflow pricing — all plans</h2>
+
+      <table>
+        <caption>Plan overview</caption>
+        <thead>
+          <tr>
+            <th>Plan</th>
+            <th>Price</th>
+            <th>Steps per day</th>
+            <th>Max message size</th>
+            <th>Max parallelism</th>
+          </tr>
+        </thead>
+        <tbody>
+          {WORKFLOW_ALL_PLANS.map((plan) => (
+            <tr key={plan.id}>
+              <td>{plan.name}</td>
+              <td>{summaryPrice(plan)}</td>
+              <td>{plan.maxStepsPerDay}</td>
+              <td>{plan.maxMessageSize}</td>
+              <td>
+                {typeof plan.maxParallelism === "number"
+                  ? plan.maxParallelism.toLocaleString()
+                  : plan.maxParallelism}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <table>
+        <caption>Fixed plans — all tiers</caption>
+        <thead>
+          <tr>
+            <th>Tier</th>
+            <th>Monthly price</th>
+            <th>Steps per day</th>
+            <th>Max bandwidth</th>
+            <th>Max message size</th>
+            <th>DLQ retention</th>
+            <th>Max HTTP response duration</th>
+            <th>Max parallelism</th>
+          </tr>
+        </thead>
+        <tbody>
+          {WORKFLOW_FIXED_PLANS.map((plan) => (
+            <tr key={plan.id}>
+              <td>{plan.name}</td>
+              <td>${plan.monthlyPrice}/month</td>
+              <td>{plan.maxStepsPerDay}</td>
+              <td>{plan.maxBandwidth}</td>
+              <td>{plan.maxMessageSize}</td>
+              <td>{plan.maxDlqRetention}</td>
+              <td>{plan.maxHttpResponseDuration}</td>
+              <td>
+                {typeof plan.maxParallelism === "number"
+                  ? plan.maxParallelism.toLocaleString()
+                  : plan.maxParallelism}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <h3>Pay as You Go — pricing details</h3>
+      <ul>
+        <li>Step price: {WORKFLOW_PAYG_PLAN.stepPrice}</li>
+        <li>Steps per day: {WORKFLOW_PAYG_PLAN.maxStepsPerDay}</li>
+        <li>
+          Bandwidth:{" "}
+          {WORKFLOW_PAYG_PLAN.maxBandwidthNote ??
+            WORKFLOW_PAYG_PLAN.maxBandwidth}
+        </li>
+        <li>Max message size: {WORKFLOW_PAYG_PLAN.maxMessageSize}</li>
+        <li>Max delay: {WORKFLOW_PAYG_PLAN.maxDelay}</li>
+        <li>
+          Max HTTP response duration:{" "}
+          {WORKFLOW_PAYG_PLAN.maxHttpResponseDuration}
+        </li>
+        <li>DLQ retention: {WORKFLOW_PAYG_PLAN.maxDlqRetention}</li>
+        <li>
+          Active schedules:{" "}
+          {typeof WORKFLOW_PAYG_PLAN.maxSchedules === "number"
+            ? WORKFLOW_PAYG_PLAN.maxSchedules.toLocaleString()
+            : WORKFLOW_PAYG_PLAN.maxSchedules}
+          {WORKFLOW_PAYG_PLAN.maxSchedulesNote !== null
+            ? ` (${WORKFLOW_PAYG_PLAN.maxSchedulesNote})`
+            : ""}
+        </li>
+        <li>
+          Parallelism:{" "}
+          {typeof WORKFLOW_PAYG_PLAN.maxParallelism === "number"
+            ? WORKFLOW_PAYG_PLAN.maxParallelism.toLocaleString()
+            : WORKFLOW_PAYG_PLAN.maxParallelism}
+        </li>
+      </ul>
+
+      <p>
+        Full machine-readable pricing is available at{" "}
+        <a href="/pricing/workflow.md">/pricing/workflow.md</a>.
+      </p>
+    </section>
+  );
+}


### PR DESCRIPTION
# DX-2724 — Summary of changes

SEO/crawlability improvements so FAQ answers and all pricing tiers appear in the server HTML (for search engines and AI agents), without changing the UI.

| Area | Change | Key files |
|------|--------|-----------|
| Homepage FAQ | New FAQ section + `FAQPage` JSON-LD, driven by one data array (includes Upstash Box) | `components/home/faq/*`, `app/page.tsx` |
| Pricing FAQ | `forceMount` + grid-rows collapse so answers stay in the HTML while the accordion still expands/collapses (covers all 6 products) | `components/pricing/accordion.tsx` |
| Pricing plan tiers | Server-rendered `sr-only` block listing **all** plans/tiers (previously hidden behind the dropdown), per product | `components/pricing/{redis,qstash,workflow,vector,search,box}/seo-plan-data.tsx`, each `app/pricing/<product>/layout.tsx` |
| Markdown alternate | `rel="alternate" type="text/markdown"` link to each `.md` version | each `app/pricing/<product>/layout.tsx` |
| Repo hygiene | Stopped tracking generated `tsconfig.tsbuildinfo` (already gitignored) | `tsconfig.tsbuildinfo` |

**Verified:** FAQ answers and all tiers present in the raw HTML body (independent of JSON-LD) across all six pricing pages; `/pricing` index serves the same; `tsc` clean; no visual changes.
