### PR TITLE
DX-2713: clean up blog RSS feed formatting and add per-author feeds

### DIFF
--- a/data/blog/2024-03-05-degree-guru.mdx
+++ b/data/blog/2024-03-05-degree-guru.mdx
@@ -4,6 +4,7 @@ slug: degree-guru
 authors:
   - arda
 tags: [vector, upstash, llm, ai]
+description: "Building a retrieval-augmented chatbot over university data with Upstash Vector."
 ---
 
 Welcome to this blog post, where we will talk about the inception and evolution of the [DegreeGuru](https://degreeguru.vercel.app/) chatbot application utilizing *Retrieval Augmented Generation (RAG)* approach. Here, we delve into the motivations that sparked its creation, tracing its development through the web of tools such as [Upstash Vector](https://upstash.com/docs/vector/overall/getstarted), [Upstash Redis](https://upstash.com/docs/redis/overall/getstarted), [Langchain](https://js.langchain.com/), [Next.js](https://nextjs.org/), [Vercel](https://vercel.com/), and the [Vercel AI SDK](https://sdk.vercel.ai/docs).

--- a/data/blog/2024-06-10-ratelimit-langchain.mdx
+++ b/data/blog/2024-06-10-ratelimit-langchain.mdx
@@ -4,6 +4,7 @@ slug: ratelimit-langchain
 authors:
   - arda
 tags: [upstash, ratelimit, langchain]
+description: "Rate-limit LangChain apps and agents using Upstash Ratelimit."
 ---
 
 In this post, we will showcase how [Upstash Ratelimit](https://upstash.com/docs/oss/sdks/ts/ratelimit/overview) can be used in LangChain in Javascript and in Python.

--- a/data/blog/2024-10-07-vercel-cost.mdx
+++ b/data/blog/2024-10-07-vercel-cost.mdx
@@ -3,6 +3,7 @@ title: "Four Ways to Reduce Your Vercel Serverless Costs"
 slug: vercel-cost
 authors: [arda]
 tags: [qstash, vercel, cost]
+description: "Practical tactics to cut Vercel function spend without rewriting your app."
 ---
 
 <Note type="info">

--- a/data/blog/2025-02-17-workflow-agents.mdx
+++ b/data/blog/2025-02-17-workflow-agents.mdx
@@ -3,6 +3,7 @@ title: "Introducing Workflow Agents"
 slug: workflow-agents
 authors: [arda]
 tags: [llm, tools, qstash, workflow, agents]
+description: "Durable, long-running AI agents built on Upstash Workflow."
 ---
 
 ## **Introducing Agents in Upstash Workflow: Durable, Scalable, and Reliable**

--- a/data/blog/2025-07-10-drizzle.mdx
+++ b/data/blog/2025-07-10-drizzle.mdx
@@ -4,6 +4,7 @@ slug: drizzle-integration
 authors:
   - arda
 tags: [drizzle, redis, cache, hash, lua]
+description: "Add a Redis cache layer to Drizzle ORM queries for faster reads in serverless apps."
 ---
 
 A while ago, we had the opportunity to collab with Drizzle ORM.

--- a/data/blog/2025-09-03-redis-timeseries.mdx
+++ b/data/blog/2025-09-03-redis-timeseries.mdx
@@ -4,6 +4,7 @@ title: "Storing Time Series Data in Redis"
 authors:
   - arda
 tags: [redis, streams, timeseries]
+description: "Patterns for modeling, writing, and querying time-series data on Redis."
 ---
 
 Time series data is everywhere in modern applications - from stock prices and sensor readings to system metrics and user analytics. If you're building an application that needs to track values over time, you've probably wondered: what's the best way to store this data in Redis?

--- a/data/blog/2025-10-05-mcp-with-redis.mdx
+++ b/data/blog/2025-10-05-mcp-with-redis.mdx
@@ -4,7 +4,7 @@ title: "Fast, Cost-Effective MCPs with Redis"
 authors:
   - arda
 tags: [redis, mcp, model-context-protocol, ai, serverless]
-description: "How Upstash Redis powers production MCP servers"
+description: "How to back a Model Context Protocol server with Redis for low-latency, cheap tool calls."
 ---
 
 The Model Context Protocol (MCP) is rapidly becoming the standard way to connect AI models with external tools and data sources. As MCP adoption grows, developers are discovering that building robust, production-ready MCP implementations requires more than just following the spec: It requires the right infrastructure. In this post, we'll explore how Redis powers three different MCP use cases: coordinating distributed serverless functions in Vercel's SSE implementation, enabling event resumability for long-running streams, and managing secure OAuth flows with Clerk.

--- a/src/app/blog/author/[author]/feed.xml/route.ts
+++ b/src/app/blog/author/[author]/feed.xml/route.ts
@@ -1,0 +1,35 @@
+import { buildRssFeed, publishedPosts, rssResponse } from "@/lib/rss-feed";
+import { authors } from "@/utils/authors";
+import { SITE_URL } from "@/utils/const";
+
+export const dynamic = "force-static";
+
+type Params = { author: string };
+
+export function generateStaticParams(): Params[] {
+  const usernames = Array.from(
+    new Set(publishedPosts().flatMap((post) => post.authors)),
+  );
+  return usernames.map((author) => ({ author }));
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Params },
+): Promise<Response> {
+  const { author } = params;
+  const displayName = authors[author]?.name ?? author;
+  const posts = publishedPosts().filter((post) =>
+    post.authors.includes(author),
+  );
+
+  const xml = await buildRssFeed({
+    title: `${displayName} – Upstash Blog`,
+    description: `Articles and tutorials by ${displayName} on the Upstash blog.`,
+    link: `${SITE_URL}/blog/author/${author}`,
+    feedUrl: `${SITE_URL}/blog/author/${author}/feed.xml`,
+    posts,
+  });
+
+  return rssResponse(xml);
+}

--- a/src/app/blog/feed.xml/route.ts
+++ b/src/app/blog/feed.xml/route.ts
@@ -1,91 +1,19 @@
-import { allPosts } from "@content";
-import { sanitizeMdx } from "@/lib/blog-markdown";
+import { buildRssFeed, publishedPosts, rssResponse } from "@/lib/rss-feed";
 import { SITE_URL } from "@/utils/const";
-import { remark } from "remark";
-import remarkGfm from "remark-gfm";
-import remarkHtml from "remark-html";
 
 export const dynamic = "force-static";
 
-function escapeXml(value: string): string {
-  return value
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-}
-
-function cdata(value: string): string {
-  return value.replaceAll("]]>", "]]]]><![CDATA[>");
-}
-
-function absolutizeHtmlUrls(html: string): string {
-  return html.replace(
-    /\b(href|src)="\/([^"]*)"/g,
-    (_match, attribute: string, path: string) =>
-      `${attribute}="${SITE_URL}/${path}"`,
-  );
-}
-
-async function markdownToHtml(markdown: string): Promise<string> {
-  const file = await remark()
-    .use(remarkGfm)
-    .use(remarkHtml, { sanitize: false })
-    .process(sanitizeMdx(markdown));
-  return absolutizeHtmlUrls(String(file));
-}
-
 export async function GET(): Promise<Response> {
-  const posts = allPosts
-    .filter((post) => !post.draft)
-    .sort(
-      (a, b) =>
-        new Date(b.publishedAt ?? b.date).getTime() -
-        new Date(a.publishedAt ?? a.date).getTime(),
-    )
-    .slice(0, 30);
+  const posts = publishedPosts().slice(0, 30);
 
-  const items = await Promise.all(
-    posts.map(async (post) => {
-      const url = `${SITE_URL}/blog/${post.slug}`;
-      const html = await markdownToHtml(post.content);
-      const author = post.authorsData[0]?.name ?? "Upstash";
-      const description =
-        post.description ??
-        "Articles and tutorials on serverless technologies from Upstash and community";
-      return `
-    <item>
-      <title><![CDATA[${cdata(post.title)}]]></title>
-      <link>${url}</link>
-      <guid isPermaLink="true">${url}</guid>
-      <pubDate>${new Date(post.publishedAt ?? post.date).toUTCString()}</pubDate>
-      <description><![CDATA[${cdata(description)}]]></description>
-      <content:encoded><![CDATA[${cdata(html)}]]></content:encoded>
-      <dc:creator><![CDATA[${cdata(author)}]]></dc:creator>
-      ${post.tags.map((tag) => `<category>${escapeXml(tag)}</category>`).join("")}
-    </item>`;
-    }),
-  );
-
-  const xml = `<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0"
-     xmlns:content="http://purl.org/rss/1.0/modules/content/"
-     xmlns:dc="http://purl.org/dc/elements/1.1/"
-     xmlns:atom="http://www.w3.org/2005/Atom">
-  <channel>
-    <title>Upstash Blog</title>
-    <link>${SITE_URL}/blog</link>
-    <description>Articles and tutorials on serverless technologies from Upstash and community.</description>
-    <language>en-US</language>
-    <atom:link href="${SITE_URL}/blog/feed.xml" rel="self" type="application/rss+xml" />
-    ${items.join("")}
-  </channel>
-</rss>`;
-
-  return new Response(xml, {
-    headers: {
-      "Content-Type": "application/rss+xml; charset=utf-8",
-      "Cache-Control": "public, max-age=3600, s-maxage=3600",
-    },
+  const xml = await buildRssFeed({
+    title: "Upstash Blog",
+    description:
+      "Articles and tutorials on serverless technologies from Upstash and community.",
+    link: `${SITE_URL}/blog`,
+    feedUrl: `${SITE_URL}/blog/feed.xml`,
+    posts,
   });
+
+  return rssResponse(xml);
 }

--- a/src/lib/rss-feed.ts
+++ b/src/lib/rss-feed.ts
@@ -1,0 +1,134 @@
+import { allPosts } from "@content";
+import { sanitizeMdx } from "@/lib/blog-markdown";
+import { SITE_URL } from "@/utils/const";
+import { remark } from "remark";
+import remarkGfm from "remark-gfm";
+import remarkHtml from "remark-html";
+
+type Post = (typeof allPosts)[number];
+
+const DEFAULT_DESCRIPTION =
+  "Articles and tutorials on serverless technologies from Upstash and community";
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function cdata(value: string): string {
+  return value.replaceAll("]]>", "]]]]><![CDATA[>");
+}
+
+function absolutizeHtmlUrls(html: string): string {
+  return html.replace(
+    /\b(href|src)="\/([^"]*)"/g,
+    (_match, attribute: string, path: string) =>
+      `${attribute}="${SITE_URL}/${path}"`,
+  );
+}
+
+/**
+ * Collapses the block-level newlines that remark-html inserts between tags so
+ * the serialized HTML sits on a single line. Only whitespace that contains a
+ * newline AND sits directly between a closing `>` and an opening `<` is
+ * removed — newlines inside `<pre>`/`<code>` blocks aren't bracketed that way,
+ * so code samples keep their line breaks.
+ */
+function inlineHtml(html: string): string {
+  return html.replace(/>\s*\n\s*</g, "><").trim();
+}
+
+async function markdownToHtml(markdown: string): Promise<string> {
+  const file = await remark()
+    .use(remarkGfm)
+    .use(remarkHtml, { sanitize: false })
+    .process(sanitizeMdx(markdown));
+  return inlineHtml(absolutizeHtmlUrls(String(file)));
+}
+
+function indent(lines: string[], spaces: number): string {
+  const pad = " ".repeat(spaces);
+  return lines.map((line) => `${pad}${line}`).join("\n");
+}
+
+async function renderItem(post: Post): Promise<string> {
+  const url = `${SITE_URL}/blog/${post.slug}`;
+  const html = await markdownToHtml(post.content);
+  const author = post.authorsData[0]?.name ?? "Upstash";
+  const description = post.description ?? DEFAULT_DESCRIPTION;
+
+  const lines = [
+    `<title><![CDATA[${cdata(post.title)}]]></title>`,
+    `<link>${url}</link>`,
+    `<guid isPermaLink="true">${url}</guid>`,
+    `<pubDate>${new Date(post.publishedAt ?? post.date).toUTCString()}</pubDate>`,
+    `<description><![CDATA[${cdata(description)}]]></description>`,
+    `<content:encoded><![CDATA[${cdata(html)}]]></content:encoded>`,
+    `<dc:creator><![CDATA[${cdata(author)}]]></dc:creator>`,
+    ...post.tags.map((tag) => `<category>${escapeXml(tag)}</category>`),
+  ];
+
+  return `    <item>\n${indent(lines, 6)}\n    </item>`;
+}
+
+export interface RssFeedOptions {
+  /** Channel <title>. */
+  title: string;
+  /** Channel <description>. */
+  description: string;
+  /** Human-facing page the feed represents, e.g. `${SITE_URL}/blog`. */
+  link: string;
+  /** Absolute URL of the feed itself, used for the atom:self link. */
+  feedUrl: string;
+  /** Posts to include, already filtered/sorted/sliced by the caller. */
+  posts: Post[];
+}
+
+export async function buildRssFeed({
+  title,
+  description,
+  link,
+  feedUrl,
+  posts,
+}: RssFeedOptions): Promise<string> {
+  const items = await Promise.all(posts.map(renderItem));
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+     xmlns:content="http://purl.org/rss/1.0/modules/content/"
+     xmlns:dc="http://purl.org/dc/elements/1.1/"
+     xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${escapeXml(title)}</title>
+    <link>${link}</link>
+    <description>${escapeXml(description)}</description>
+    <language>en-US</language>
+    <atom:link href="${feedUrl}" rel="self" type="application/rss+xml" />
+${items.join("\n")}
+  </channel>
+</rss>
+`;
+}
+
+export function rssResponse(xml: string): Response {
+  return new Response(xml, {
+    headers: {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, s-maxage=3600",
+    },
+  });
+}
+
+/** Published posts, newest first. */
+export function publishedPosts(): Post[] {
+  return allPosts
+    .filter((post) => !post.draft)
+    .sort(
+      (a, b) =>
+        new Date(b.publishedAt ?? b.date).getTime() -
+        new Date(a.publishedAt ?? a.date).getTime(),
+    );
+}


### PR DESCRIPTION
- Extract shared feed builder into src/lib/rss-feed.ts
- Fix inconsistent indentation and stray blank lines in feed.xml
- Collapse content:encoded HTML onto one line (preserving code blocks)
- Add /blog/author/[author]/feed.xml with full post history (no 30-post cap)