### PR TITLE
Blog: How SREs Use Upstash QStash, Workflow, and Redis to Automate Reliability Without Servers

### DIFF
--- a/data/blog/2026-06-13-how-sres-use-upstash-qstash.mdx
+++ b/data/blog/2026-06-13-how-sres-use-upstash-qstash.mdx
@@ -1,0 +1,67 @@
+---
+title: "How SREs Use Upstash QStash, Workflow, and Redis to Automate Reliability Without Servers"
+slug: how-sres-use-upstash-qstash
+authors: [burak]
+tags: [serverless, redis, qstash, workflow]
+description: "Ditch cron jobs, manual retries, and always-on infra — here’s the durable, serverless pattern."
+publishedAt: "2026-06-13T12:18:39.780Z"
+---
+
+# How SREs Use Upstash QStash, Workflow, and Redis to Automate Reliability Without Servers
+testim testtt
+SREs spend too much time babysitting cron jobs, writing retry wrappers, and keeping always-on services alive just to run reliability tasks. Upstash lets you replace all of that with three serverless pieces that already talk to each other.
+
+## The old pain
+A typical reliability loop looks like: schedule a health check, call an API, rate-limit the call, retry on failure, store results. Each piece usually needs a separate queue, a VM, or a Lambda + CloudWatch cron. Failures get lost in logs.
+
+## The Upstash pattern
+1. **Redis** (Ratelimit SDK) protects downstream APIs at the edge.
+2. **QStash** schedules the job and guarantees delivery with built-in retries.
+3. **Workflow** turns the whole sequence into durable steps that pick up exactly where they left off.
+
+No servers, no state machines to manage.
+
+## Tiny working sketch
+```ts
+import { serve } from "@upstash/workflow/nextjs";
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
+
+const ratelimit = new Ratelimit({
+  redis: Redis.fromEnv(),
+  limiter: Ratelimit.slidingWindow(5, "10 s"),
+});
+
+export const { POST } = serve(async (context) => {
+  await context.run("check-rate", async () => {
+    const { success } = await ratelimit.limit("health-check");
+    if (!success) throw new Error("rate limited");
+  });
+  const result = await context.call("call-api", {
+    url: "https://api.example.com/health",
+    method: "GET",
+  });
+  await context.run("store", () => Redis.fromEnv().set("last-check", result));
+});
+```
+
+Deploy the route, create a QStash schedule pointing at it, and you’re done. Every step is retried automatically; rate limits are enforced globally; results land in Redis.
+
+## Why this matters for SREs
+- Zero infra to patch or scale.
+- 99.99% uptime SLA on the platform itself.
+- Observability via Datadog integration for the same metrics you already watch.
+
+The result: reliability work that runs itself instead of running your on-call rotation.
+
+Testimt testtts
+
+## Closing Poem
+No servers hum in dead of night,
+QStash keeps schedules running right.
+Workflows resume where failures fall,
+Redis guards the rate for all.
+SREs rest easy, tasks run free—
+serverless magic, Upstash spree.
+
+## E2E_MARKER_1781359581


### PR DESCRIPTION
Draft blog post generated by **blogx** from the deep dive `how-an-sre-can-use-upstash-for-making-their-job-easier`.

**Positioning:** Good coverage exists around the individual products and Upstash’s internal SRE work, but no post yet shows the combined SRE pattern for replacing cron, manual retries, and rate-limit infra. The fresh angle is practical, SRE-centric: concrete workflows that tie edge Redis rate limiting, QStash scheduling/retries, and durable Workflow steps into one zero-server reliability loop.

> Auto-opened for human review — proofread, tweak, and merge when ready. Updates pushed from the blogx editor land on this branch.