### PR TITLE
fix: add redirects for orphaned URLs (/console, /legal/terms, moved blog, context7)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -55,7 +55,6 @@ const nextConfig = {
       source: "/docs",
       destination: "https://upstash.mintlify.dev/docs",
     },
-    { source: "/pricing", destination: "/pricing/redis" },
     {
       source: "/docs/:match*",
       destination: "https://upstash.mintlify.dev/docs/:match*",

--- a/src/components/home/price/redis.tsx
+++ b/src/components/home/price/redis.tsx
@@ -47,7 +47,7 @@ export default function PriceRedis() {
 
       <PriceHr />
 
-      <PriceButton href="/pricing">More information</PriceButton>
+      <PriceButton href="/pricing/redis">More information</PriceButton>
     </PriceBox>
   );
 }

--- a/src/components/home/serverless/price-scale-to-zero.tsx
+++ b/src/components/home/serverless/price-scale-to-zero.tsx
@@ -5,7 +5,7 @@ export default function PriceScaleToZero() {
   return (
     <ServerlessBox className="md:col-span-3">
       <header>
-        <ServerlessTitle link="/pricing" title="Pricing">
+        <ServerlessTitle link="/pricing/redis" title="Pricing">
           Price scales to zero
         </ServerlessTitle>
         <ServerlessSummary>

--- a/src/components/master/nav-mobile.tsx
+++ b/src/components/master/nav-mobile.tsx
@@ -84,7 +84,7 @@ const NavItems: {
   },
   {
     name: "Pricing",
-    href: "/pricing",
+    href: "/pricing/redis",
   },
   {
     name: "Customers",

--- a/src/components/master/new-nav.tsx
+++ b/src/components/master/new-nav.tsx
@@ -32,7 +32,7 @@ export default function NewNavigation() {
             "pricing" === segment ? "bg-bg-mute text-primary-text" : "",
           )}
         >
-          <Link href="/pricing">Pricing</Link>
+          <Link href="/pricing/redis">Pricing</Link>
         </NavigationMenu.Link>
       </NavigationMenu.Item>
 

--- a/vercel.json
+++ b/vercel.json
@@ -27,6 +27,22 @@
     {
       "source": "/redis-api-compatibility",
       "destination": "https://upstash.com/docs/redis/features/restapi#rest-redis-api-compatibility"
+    },
+    {
+      "source": "/console",
+      "destination": "https://console.upstash.com"
+    },
+    {
+      "source": "/legal/terms",
+      "destination": "/trust/terms.pdf"
+    },
+    {
+      "source": "/blog/nextjs-edge-functions",
+      "destination": "/blog/getstarted-nextjs-edge-with-redis"
+    },
+    {
+      "source": "/context7",
+      "destination": "https://context7.com"
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -43,6 +43,10 @@
     {
       "source": "/context7",
       "destination": "https://context7.com"
+    },
+    {
+      "source": "/pricing",
+      "destination": "/pricing/redis"
     }
   ]
 }


### PR DESCRIPTION
Recovers backlinks pointing at paths that now 404: /console (socket.dev), /legal/terms (deepwiki), /blog/nextjs-edge-functions (contra), and /context7 (lobehub) -> context7.com.