### PR TITLE
DX-2835: optimize /redis page for 'redis cloud'

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -90,7 +90,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
 
 const title = "Upstash: Serverless Data Platform";
 const description =
-  "Upstash is a serverless data platform providing low latency and high scalability for real-time applications. Optimize your data infrastructure with Upstash's managed services for Redis, Vector, QStash, and other key data technologies.";
+  "Upstash is a serverless data platform with fully managed, cloud-hosted Redis — single-digit millisecond latency, global replication, and pay-as-you-go pricing. Plus Vector, Search, and QStash for real-time apps.";
 
 export async function generateMetadata() {
   return {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -90,7 +90,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
 
 const title = "Upstash: Serverless Data Platform";
 const description =
-  "Upstash is a serverless data platform with fully managed, cloud-hosted Redis — single-digit millisecond latency, global replication, and pay-as-you-go pricing. Plus Vector, Search, and QStash for real-time apps.";
+  "Upstash is a serverless data platform providing low latency and high scalability for real-time applications. Optimize your data infrastructure with Upstash's managed services for Redis, Vector, QStash, and other key data technologies.";
 
 export async function generateMetadata() {
   return {

--- a/src/app/redis/section-cta.tsx
+++ b/src/app/redis/section-cta.tsx
@@ -2,6 +2,7 @@ import Bg from "@/components/bg";
 import Button from "@/components/button";
 import Container from "@/components/container";
 import cx from "@/utils/cx";
+import { IconPlus, IconTag } from "@tabler/icons-react";
 import Link from "next/link";
 
 export default function SectionCta() {
@@ -29,10 +30,14 @@ export default function SectionCta() {
           <Button asChild variant="primary" className="h-[46px] px-6">
             <a href="https://console.upstash.com/redis" target="_blank">
               Create Database
+              <IconPlus size={24} />
             </a>
           </Button>
           <Button asChild variant="default" className="h-[46px] px-6">
-            <Link href="/pricing/redis">View Pricing</Link>
+            <Link href="/pricing/redis">
+              View Pricing
+              <IconTag size={24} />
+            </Link>
           </Button>
         </div>
       </Container>

--- a/src/app/redis/section-hero.tsx
+++ b/src/app/redis/section-hero.tsx
@@ -3,7 +3,7 @@ import Button from "@/components/button";
 import Container from "@/components/container";
 import IconRedis from "@/components/icon-redis";
 import cx from "@/utils/cx";
-import { IconNotes, IconPlus } from "@tabler/icons-react";
+import { IconNotes, IconPlus, IconTag } from "@tabler/icons-react";
 import Link from "next/link";
 
 export default function SectionHero() {
@@ -23,16 +23,16 @@ export default function SectionHero() {
           >
             <IconRedis className="size-12 shrink-0 md:size-20" />
             <span>
-              <span className="block">Serverless</span>
-              <span className="block">Redis Database</span>
+              <span className="block">Serverless Redis</span>
+              <span className="block">in the Cloud</span>
             </span>
           </h1>
 
           <p className="mt-6 max-w-2xl text-balance text-lg text-text-mute md:text-2xl">
-            Upstash runs Redis as a fully managed, serverless database with
-            single-digit millisecond latency and durable storage. You pay only
-            for what you use, and there are no servers to run. Connect over HTTP
-            or the standard Redis protocol.
+            Upstash runs Redis in the cloud as a fully managed, serverless
+            database with single-digit millisecond latency and durable storage.
+            You pay only for what you use, and there are no servers to run.
+            Connect over HTTP or the standard Redis protocol (TCP).
           </p>
 
           <div className="mt-10 flex flex-col justify-center gap-3 sm:flex-row">
@@ -51,6 +51,7 @@ export default function SectionHero() {
             <Link href="/pricing/redis">
               <Button variant="default" className="h-[42px] px-5">
                 View Pricing
+                <IconTag size={24} />
               </Button>
             </Link>
           </div>

--- a/src/app/redis/section-what-is.tsx
+++ b/src/app/redis/section-what-is.tsx
@@ -31,11 +31,12 @@ export default function SectionWhatIs() {
             instantly.
           </p>
           <p>
-            <strong>Upstash</strong> runs Redis as a serverless database, so
-            there is nothing to provision and no failover to manage. You create
-            a database in seconds, connect over HTTP or the Redis protocol, and
-            pay only for the requests you make. Databases can be replicated
-            across regions for high availability close to your users.
+            <strong>Upstash</strong> runs Redis as a fully managed, serverless
+            database in the cloud, so there is nothing to provision and no
+            failover to manage. You create a cloud Redis database in seconds,
+            connect over HTTP or the Redis protocol, and pay only for the
+            requests you make. Databases can be replicated across regions for
+            high availability close to your users.
           </p>
         </div>
       </Container>

--- a/src/components/home/product-new/index.tsx
+++ b/src/components/home/product-new/index.tsx
@@ -8,7 +8,12 @@ import { HeroTabVector } from "@/components/home/hero/hero-tab-vector";
 import { HeroTabWorkflow } from "@/components/home/hero/hero-tab-workflow";
 import cx from "@/utils/cx";
 import { Product } from "@/utils/type";
-import { IconArrowUpRight, IconNotes, IconPlus } from "@tabler/icons-react";
+import {
+  IconArrowRight,
+  IconArrowUpRight,
+  IconNotes,
+  IconPlus,
+} from "@tabler/icons-react";
 import Link from "next/link";
 import React, { useState } from "react";
 import { HeroTabBox } from "../hero/hero-tab-box";
@@ -61,7 +66,8 @@ const HeroProductTagline = ({ activeProduct }: { activeProduct: Product }) => {
         {activeProduct === Product.REDIS && (
           <Link href="/redis">
             <Button variant={"default"} className="h-[42px] px-5">
-              Learn more
+              Explore Redis
+              <IconArrowRight size={24} />
             </Button>
           </Link>
         )}


### PR DESCRIPTION
## Summary

Search Console shows we rank ~position 7.6 for **redis cloud**, but the ranking page is the generic homepage (not our dedicated `/redis` page), and Google renders a customer testimonial as the snippet → 1.56% CTR. This PR strengthens the `/redis` page's topical relevance for "redis cloud" / "managed redis" and cleans up the button UI.

## Changes

- Hero H1: "Serverless Redis Database" → **"Serverless Redis in the Cloud"**
- Weave "fully managed" / "in the cloud" / "cloud Redis database" phrasing into the hero subhead and "What is a Redis database?" copy
- Homepage Redis tile link: generic "Learn more" anchor → descriptive **"Explore Redis"**
- Add icons to the View Pricing (`IconTag`), Create Database (`IconPlus`), and Explore Redis (`IconArrowRight`) buttons for consistency

The homepage meta description rewrite is included as a commit and then reverted — kept in history for reference, pending a separate landing-page review before we change the root layout.