### PR TITLE
DX-2835: surface Redis in homepage hero and product copy

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -88,9 +88,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   );
 }
 
-const title = "Upstash: Serverless Data Platform";
+const title = "Upstash: Serverless Data Platform for Redis, Vector & Messaging";
 const description =
-  "Upstash is a serverless data platform providing low latency and high scalability for real-time applications. Optimize your data infrastructure with Upstash's managed services for Redis, Vector, QStash, and other key data technologies.";
+  "Upstash is a serverless data platform providing low latency and high scalability for real-time and AI applications. Get fully managed Redis, Vector, and messaging with pay-as-you-go pricing — create a database in seconds, with no servers to manage.";
 
 export async function generateMetadata() {
   return {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -88,9 +88,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   );
 }
 
-const title = "Upstash: Serverless Data Platform for Redis, Vector & Messaging";
+const title = "Upstash: Serverless Data Platform - Redis, Vector, Search";
 const description =
-  "Upstash is a serverless data platform providing low latency and high scalability for real-time and AI applications. Get fully managed Redis, Vector, and messaging with pay-as-you-go pricing — create a database in seconds, with no servers to manage.";
+  "Serverless Redis, Vector and Search databases with low latency and pay-as-you-go pricing. Upstash is the data platform for modern and AI applications — create a Redis database in seconds.";
 
 export async function generateMetadata() {
   return {
@@ -114,7 +114,7 @@ export async function generateMetadata() {
       url: "/",
       title,
       description,
-      siteName: title,
+      siteName: "Upstash",
       images: "/og-home.jpg",
     },
     twitter: {

--- a/src/app/redis/page.tsx
+++ b/src/app/redis/page.tsx
@@ -11,7 +11,7 @@ import { Metadata } from "next";
 
 const title = "Redis Database - Upstash";
 const description =
-  "Upstash is a serverless Redis database with low latency, durable storage, and pay-as-you-go pricing. Create a fully managed Redis database in seconds.";
+  "Upstash is a serverless Redis database with low latency, durable storage, and pay-as-you-go pricing. Create a fully managed Redis database in the cloud in seconds.";
 
 export const metadata: Metadata = {
   title,

--- a/src/components/home/hero/index.tsx
+++ b/src/components/home/hero/index.tsx
@@ -26,7 +26,7 @@ export default function HomeHero() {
 
         {/* hero subtitle*/}
         <h2 className={cx("mt-2 text-lg md:text-2xl", "text-text-mute")}>
-          Serverless Redis, Vector, and messaging for real-time apps
+          One platform for all your data needs
         </h2>
 
         <div className="mt-6">

--- a/src/components/home/hero/index.tsx
+++ b/src/components/home/hero/index.tsx
@@ -26,7 +26,7 @@ export default function HomeHero() {
 
         {/* hero subtitle*/}
         <h2 className={cx("mt-2 text-lg md:text-2xl", "text-text-mute")}>
-          The single platform for all your data needs
+          Serverless Redis, Vector, and messaging for real-time apps
         </h2>
 
         <div className="mt-6">

--- a/src/components/home/product-new/index.tsx
+++ b/src/components/home/product-new/index.tsx
@@ -18,7 +18,7 @@ const UPSTASH_SKILL_COMMAND =
 
 const taglines = {
   [Product.REDIS]: {
-    title: "Low-latency, serverless key-value store",
+    title: "Low-latency, serverless Redis in the cloud",
     docsLink: "https://upstash.com/docs/redis",
     consoleLink: "https://console.upstash.com/redis",
   },


### PR DESCRIPTION
Put the target terms into visible above-the-fold copy so Google has relevant text for the 'redis cloud' snippet instead of a customer testimonial:
- Hero subtitle: 'The single platform for all your data needs' ->
  'Serverless Redis, Vector, and messaging for real-time apps'
- Redis tab tagline: 'Low-latency, serverless key-value store' ->
  'Low-latency, serverless Redis in the cloud'

builds on top of https://github.com/upstash/upstash-web/commit/8916a8a97a91f3b2f5638521a6984a09abad5853