### PR TITLE
DX-2835: surface all homepage product tabs to crawlers + fix /redis title

### DIFF
--- a/src/app/redis/page.tsx
+++ b/src/app/redis/page.tsx
@@ -9,7 +9,7 @@ import { REDIS_FAQ } from "@/app/redis/faq";
 import { generateFaqSchema } from "@/utils/structured-schema-generators";
 import { Metadata } from "next";
 
-const title = "Redis Database - Upstash";
+const title = "Redis Database";
 const description =
   "Upstash is a serverless Redis database with low latency, durable storage, and pay-as-you-go pricing. Create a fully managed Redis database in the cloud in seconds.";
 
@@ -29,13 +29,13 @@ export const metadata: Metadata = {
   },
   openGraph: {
     type: "website",
-    title,
+    title: `${title} | Upstash`,
     description,
     url: "/redis",
   },
   twitter: {
     card: "summary_large_image",
-    title,
+    title: `${title} | Upstash`,
     description,
   },
 };

--- a/src/components/home/hero/hero-tab-box.tsx
+++ b/src/components/home/hero/hero-tab-box.tsx
@@ -1,88 +1,12 @@
-import {
-  HeroTabFeatureBullet,
-  HeroTabFeatureCont,
-  HeroTabFeatureLi,
-  HeroTabFeatureTitle,
-  HeroTabFeatureUl,
-} from "@/components/home/hero/hero-tab";
-import { IconCircle1, IconCircle2, IconCircle3 } from "@tabler/icons-react";
+import { HeroTabFeatures } from "@/components/home/hero/hero-tab";
+import { PRODUCT_FEATURES } from "@/components/home/product-new/product-features";
+import { Product } from "@/utils/type";
 import { CodeSnippetsBox } from "../serverless/code-snippets-box";
 
 export function HeroTabBox() {
   return (
     <>
-      <HeroTabFeatureCont>
-        <HeroTabFeatureTitle>Built for AI Agents</HeroTabFeatureTitle>
-        <HeroTabFeatureUl>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle1 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Secure, isolated cloud containers
-          </HeroTabFeatureLi>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle2 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Built-in Claude Code and Codex agents
-          </HeroTabFeatureLi>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle3 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Full shell, filesystem, and git access
-          </HeroTabFeatureLi>
-        </HeroTabFeatureUl>
-      </HeroTabFeatureCont>
-
-      <HeroTabFeatureCont>
-        <HeroTabFeatureTitle>Durable & Persistent</HeroTabFeatureTitle>
-        <HeroTabFeatureUl>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle1 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Infinite lifespan with auto freeze/resume
-          </HeroTabFeatureLi>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle2 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Persistent storage across sessions
-          </HeroTabFeatureLi>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle3 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Usage-based pricing, pay only when active
-          </HeroTabFeatureLi>
-        </HeroTabFeatureUl>
-      </HeroTabFeatureCont>
-
-      <HeroTabFeatureCont>
-        <HeroTabFeatureTitle>Scales Seamlessly</HeroTabFeatureTitle>
-        <HeroTabFeatureUl>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle1 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Serverless, no infrastructure to manage
-          </HeroTabFeatureLi>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle2 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Scale to hundreds of boxes instantly
-          </HeroTabFeatureLi>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle3 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Multi-agent orchestration support
-          </HeroTabFeatureLi>
-        </HeroTabFeatureUl>
-      </HeroTabFeatureCont>
-
+      <HeroTabFeatures groups={PRODUCT_FEATURES[Product.BOX]} />
       <CodeSnippetsBox />
     </>
   );

--- a/src/components/home/hero/hero-tab-qstash.tsx
+++ b/src/components/home/hero/hero-tab-qstash.tsx
@@ -1,94 +1,12 @@
-import {
-  HeroTabFeatureBullet,
-  HeroTabFeatureCont,
-  HeroTabFeatureLi,
-  HeroTabFeatureTitle,
-  HeroTabFeatureUl,
-} from "@/components/home/hero/hero-tab";
-import { IconCircle1, IconCircle2, IconCircle3 } from "@tabler/icons-react";
+import { HeroTabFeatures } from "@/components/home/hero/hero-tab";
+import { PRODUCT_FEATURES } from "@/components/home/product-new/product-features";
+import { Product } from "@/utils/type";
 import { CodeSnippetsQStash } from "../serverless/code-snippets-qstash";
 
 export function HeroTabQStash() {
   return (
     <>
-      <HeroTabFeatureCont>
-        <HeroTabFeatureTitle>
-          Serverless <br className="hidden sm:block" /> Messaging
-        </HeroTabFeatureTitle>
-        <HeroTabFeatureUl>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle1 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Effortless communication between serverless functions
-          </HeroTabFeatureLi>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle2 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Decouple your microservices architecture
-          </HeroTabFeatureLi>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle3 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Scale your messaging infrastructure without limits
-          </HeroTabFeatureLi>
-        </HeroTabFeatureUl>
-      </HeroTabFeatureCont>
-
-      <HeroTabFeatureCont>
-        <HeroTabFeatureTitle>
-          Scheduled Tasks <br className="hidden sm:block" /> with CRON
-        </HeroTabFeatureTitle>
-        <HeroTabFeatureUl>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle1 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Easily set up recurring tasks and jobs
-          </HeroTabFeatureLi>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle2 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Flexible scheduling with CRON syntax
-          </HeroTabFeatureLi>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle3 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Automate your workflows with precision
-          </HeroTabFeatureLi>
-        </HeroTabFeatureUl>
-      </HeroTabFeatureCont>
-
-      <HeroTabFeatureCont>
-        <HeroTabFeatureTitle>
-          Intelligent <br className="hidden sm:block" /> Retry Mechanism
-        </HeroTabFeatureTitle>
-        <HeroTabFeatureUl>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle1 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Automatically retry failed tasks
-          </HeroTabFeatureLi>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle2 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Ensure task completion in unreliable environments
-          </HeroTabFeatureLi>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle3 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Configurable retry policies to suit your needs
-          </HeroTabFeatureLi>
-        </HeroTabFeatureUl>
-      </HeroTabFeatureCont>
-
+      <HeroTabFeatures groups={PRODUCT_FEATURES[Product.QSTASH]} />
       <CodeSnippetsQStash />
     </>
   );

--- a/src/components/home/hero/hero-tab-redis.tsx
+++ b/src/components/home/hero/hero-tab-redis.tsx
@@ -1,95 +1,12 @@
-import {
-  HeroTabFeatureBullet,
-  HeroTabFeatureCont,
-  HeroTabFeatureLi,
-  HeroTabFeatureTitle,
-  HeroTabFeatureUl,
-} from "@/components/home/hero/hero-tab";
-import { IconCircle1, IconCircle2, IconCircle3 } from "@tabler/icons-react";
+import { HeroTabFeatures } from "@/components/home/hero/hero-tab";
+import { PRODUCT_FEATURES } from "@/components/home/product-new/product-features";
+import { Product } from "@/utils/type";
 import { CodeSnippetsRedis } from "../serverless/code-snippets-redis";
 
 export function HeroTabRedis() {
   return (
     <>
-      <HeroTabFeatureCont>
-        <HeroTabFeatureTitle>
-          Highly Available, <br className="hidden sm:block" /> Infinitely
-          Scalable
-        </HeroTabFeatureTitle>
-        <HeroTabFeatureUl>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle1 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            99.99% uptime guarantee
-          </HeroTabFeatureLi>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle2 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Automatic scaling to meet your demands
-          </HeroTabFeatureLi>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle3 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            No server management required
-          </HeroTabFeatureLi>
-        </HeroTabFeatureUl>
-      </HeroTabFeatureCont>
-
-      <HeroTabFeatureCont>
-        <HeroTabFeatureTitle>
-          Global <br className="hidden sm:block" /> Low Latency
-        </HeroTabFeatureTitle>
-        <HeroTabFeatureUl>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle1 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Lightning-fast response times worldwide
-          </HeroTabFeatureLi>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle2 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Multi-region replication options
-          </HeroTabFeatureLi>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle3 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Optimize for your users, wherever they are
-          </HeroTabFeatureLi>
-        </HeroTabFeatureUl>
-      </HeroTabFeatureCont>
-
-      <HeroTabFeatureCont>
-        <HeroTabFeatureTitle>
-          Persistent Redis, <br className="hidden sm:block" /> In-Memory Speed
-        </HeroTabFeatureTitle>
-        <HeroTabFeatureUl>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle1 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            In-memory speed with disk-like persistence
-          </HeroTabFeatureLi>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle2 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Data safety without sacrificing performance
-          </HeroTabFeatureLi>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle3 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Automatic backups
-          </HeroTabFeatureLi>
-        </HeroTabFeatureUl>
-      </HeroTabFeatureCont>
-
+      <HeroTabFeatures groups={PRODUCT_FEATURES[Product.REDIS]} />
       <CodeSnippetsRedis />
     </>
   );

--- a/src/components/home/hero/hero-tab-vector.tsx
+++ b/src/components/home/hero/hero-tab-vector.tsx
@@ -1,100 +1,12 @@
-import {
-  HeroTabFeatureBullet,
-  HeroTabFeatureCont,
-  HeroTabFeatureLi,
-  HeroTabFeatureTitle,
-  HeroTabFeatureUl,
-} from "@/components/home/hero/hero-tab";
-import { IconCircle1, IconCircle2, IconCircle3 } from "@tabler/icons-react";
+import { HeroTabFeatures } from "@/components/home/hero/hero-tab";
+import { PRODUCT_FEATURES } from "@/components/home/product-new/product-features";
+import { Product } from "@/utils/type";
 import { CodeSnippetsVector } from "../serverless/code-snippets-vector";
 
 export function HeroTabVector() {
   return (
     <>
-      <HeroTabFeatureCont>
-        <HeroTabFeatureTitle>
-          Massive <br className="hidden sm:block" /> Scalability
-        </HeroTabFeatureTitle>
-        <HeroTabFeatureUl>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle1 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Handle hundreds of millions of vectors
-          </HeroTabFeatureLi>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle2 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Seamless scaling as your data grows
-          </HeroTabFeatureLi>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle3 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Maintain performance at any scale
-          </HeroTabFeatureLi>
-        </HeroTabFeatureUl>
-      </HeroTabFeatureCont>
-
-      <HeroTabFeatureCont>
-        <HeroTabFeatureTitle>
-          Disk-Based <br className="hidden sm:block" /> Algorithm for Efficiency
-        </HeroTabFeatureTitle>
-        <HeroTabFeatureUl>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle1 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Optimize storage and performance
-          </HeroTabFeatureLi>
-          <HeroTabFeatureLi>
-            {" "}
-            <HeroTabFeatureBullet>
-              <IconCircle2 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Cost-effective solution for large datasets
-          </HeroTabFeatureLi>
-          <HeroTabFeatureLi>
-            {" "}
-            <HeroTabFeatureBullet>
-              <IconCircle3 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Balance between speed and resource usage
-          </HeroTabFeatureLi>
-        </HeroTabFeatureUl>
-      </HeroTabFeatureCont>
-
-      <HeroTabFeatureCont>
-        <HeroTabFeatureTitle>
-          Powerful Metadata <br className="hidden sm:block" /> Store with SQL
-          Support
-        </HeroTabFeatureTitle>
-        <HeroTabFeatureUl>
-          <HeroTabFeatureLi>
-            {" "}
-            <HeroTabFeatureBullet>
-              <IconCircle1 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Rich querying capabilities with familiar SQL syntax
-          </HeroTabFeatureLi>
-          <HeroTabFeatureLi>
-            {" "}
-            <HeroTabFeatureBullet>
-              <IconCircle2 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Easily combine vector similarity search with metadata filtering
-          </HeroTabFeatureLi>
-          <HeroTabFeatureLi>
-            {" "}
-            <HeroTabFeatureBullet>
-              <IconCircle3 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Flexible data organization and retrieval
-          </HeroTabFeatureLi>
-        </HeroTabFeatureUl>
-      </HeroTabFeatureCont>
-
+      <HeroTabFeatures groups={PRODUCT_FEATURES[Product.VECTOR]} />
       <CodeSnippetsVector />
     </>
   );

--- a/src/components/home/hero/hero-tab-workflow.tsx
+++ b/src/components/home/hero/hero-tab-workflow.tsx
@@ -1,94 +1,12 @@
-import {
-  HeroTabFeatureBullet,
-  HeroTabFeatureCont,
-  HeroTabFeatureLi,
-  HeroTabFeatureTitle,
-  HeroTabFeatureUl,
-} from "@/components/home/hero/hero-tab";
-import { IconCircle1, IconCircle2, IconCircle3 } from "@tabler/icons-react";
+import { HeroTabFeatures } from "@/components/home/hero/hero-tab";
+import { PRODUCT_FEATURES } from "@/components/home/product-new/product-features";
+import { Product } from "@/utils/type";
 import { CodeSnippetsWorkflow } from "../serverless/code-snippets-workflow";
 
 export function HeroTabWorkflow() {
   return (
     <>
-      <HeroTabFeatureCont>
-        <HeroTabFeatureTitle>
-          Serverless <br className="hidden sm:block" /> Function Orchestration
-        </HeroTabFeatureTitle>
-        <HeroTabFeatureUl>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle1 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Coordinate complex serverless workflows
-          </HeroTabFeatureLi>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle2 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Integrate and manage multiple functions with ease
-          </HeroTabFeatureLi>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle3 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Streamline your serverless architecture
-          </HeroTabFeatureLi>
-        </HeroTabFeatureUl>
-      </HeroTabFeatureCont>
-
-      <HeroTabFeatureCont>
-        <HeroTabFeatureTitle>
-          Eliminate <br className="hidden sm:block" /> Function Timeouts
-        </HeroTabFeatureTitle>
-        <HeroTabFeatureUl>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle1 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Execute long-running processes without constraints
-          </HeroTabFeatureLi>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle2 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            No more arbitrary time limits on your operations
-          </HeroTabFeatureLi>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle3 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Focus on your logic, not on timing workarounds
-          </HeroTabFeatureLi>
-        </HeroTabFeatureUl>
-      </HeroTabFeatureCont>
-
-      <HeroTabFeatureCont>
-        <HeroTabFeatureTitle>
-          Automatic <br className="hidden sm:block" /> Error Recovery
-        </HeroTabFeatureTitle>
-        <HeroTabFeatureUl>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle1 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Built-in resilience for your workflows
-          </HeroTabFeatureLi>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle2 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Automatically retry failed steps
-          </HeroTabFeatureLi>
-          <HeroTabFeatureLi>
-            <HeroTabFeatureBullet>
-              <IconCircle3 stroke={1.5} />
-            </HeroTabFeatureBullet>
-            Ensure robust execution even in unpredictable environments
-          </HeroTabFeatureLi>
-        </HeroTabFeatureUl>
-      </HeroTabFeatureCont>
-
+      <HeroTabFeatures groups={PRODUCT_FEATURES[Product.WORKFLOW]} />
       <CodeSnippetsWorkflow />
     </>
   );

--- a/src/components/home/hero/hero-tab.tsx
+++ b/src/components/home/hero/hero-tab.tsx
@@ -1,5 +1,49 @@
+import type { ProductFeatureGroup } from "@/components/home/product-new/product-features";
 import cx from "@/utils/cx";
+import { IconCircle1, IconCircle2, IconCircle3 } from "@tabler/icons-react";
 import React from "react";
+
+const BULLET_ICONS = [IconCircle1, IconCircle2, IconCircle3];
+
+/**
+ * Renders a product's feature groups from the shared PRODUCT_FEATURES data.
+ * Used by every hero-tab-*.tsx so the visible tab and the sr-only crawlable
+ * mirror (product-seo-data.tsx) stay in sync from one source of truth.
+ */
+export function HeroTabFeatures({ groups }: { groups: ProductFeatureGroup[] }) {
+  return (
+    <>
+      {groups.map((group, groupIndex) => (
+        <HeroTabFeatureCont key={groupIndex}>
+          <HeroTabFeatureTitle>
+            {group.title.map((line, lineIndex) =>
+              lineIndex === 0 ? (
+                <React.Fragment key={lineIndex}>{line} </React.Fragment>
+              ) : (
+                <React.Fragment key={lineIndex}>
+                  <br className="hidden sm:block" /> {line}
+                </React.Fragment>
+              ),
+            )}
+          </HeroTabFeatureTitle>
+          <HeroTabFeatureUl>
+            {group.bullets.map((bullet, bulletIndex) => {
+              const Icon = BULLET_ICONS[bulletIndex] ?? IconCircle3;
+              return (
+                <HeroTabFeatureLi key={bulletIndex}>
+                  <HeroTabFeatureBullet>
+                    <Icon stroke={1.5} />
+                  </HeroTabFeatureBullet>
+                  {bullet}
+                </HeroTabFeatureLi>
+              );
+            })}
+          </HeroTabFeatureUl>
+        </HeroTabFeatureCont>
+      ))}
+    </>
+  );
+}
 
 export function HeroTabFeatureCont({
   className,

--- a/src/components/home/product-new/index.tsx
+++ b/src/components/home/product-new/index.tsx
@@ -17,45 +17,14 @@ import {
 import Link from "next/link";
 import React, { useState } from "react";
 import { HeroTabBox } from "../hero/hero-tab-box";
+import { PRODUCT_TAGLINES } from "./product-features";
+import ProductSeoData from "./product-seo-data";
 
 const UPSTASH_SKILL_COMMAND =
   "npx skills add https://github.com/upstash/skills --skill upstash";
 
-const taglines = {
-  [Product.REDIS]: {
-    title: "Serverless Redis in the cloud with low latency and durable storage",
-    docsLink: "https://upstash.com/docs/redis",
-    consoleLink: "https://console.upstash.com/redis",
-  },
-  [Product.VECTOR]: {
-    title: "Serverless Vector database for high-performance search at scale",
-    docsLink: "https://upstash.com/docs/vector",
-    consoleLink: "https://console.upstash.com/vector",
-  },
-  [Product.QSTASH]: {
-    title: "Serverless messaging and scheduling via HTTP",
-    docsLink: "https://upstash.com/docs/qstash",
-    consoleLink: "https://console.upstash.com/qstash",
-  },
-  [Product.WORKFLOW]: {
-    title: "Durable, reliable and performant serverless functions",
-    docsLink: "https://upstash.com/docs/workflow",
-    consoleLink: "https://console.upstash.com/workflow",
-  },
-  [Product.SEARCH]: {
-    title: "Serverless AI search at scale",
-    docsLink: "https://upstash.com/docs/search",
-    consoleLink: "https://console.upstash.com/search",
-  },
-  [Product.BOX]: {
-    title: "Secure cloud containers for AI agents",
-    docsLink: "https://upstash.com/docs/box",
-    consoleLink: "https://console.upstash.com/box",
-  },
-} as const;
-
 const HeroProductTagline = ({ activeProduct }: { activeProduct: Product }) => {
-  const { title, docsLink, consoleLink } = taglines[activeProduct];
+  const { title, docsLink, consoleLink } = PRODUCT_TAGLINES[activeProduct];
 
   return (
     <div className="mb-8 flex flex-col items-center gap-4 py-4">
@@ -145,6 +114,8 @@ export default function HomeProductNew() {
             {activeProduct === Product.BOX && <HeroTabBox />}
           </div>
         </div>
+
+        <ProductSeoData />
       </Container>
     </section>
   );

--- a/src/components/home/product-new/product-features.ts
+++ b/src/components/home/product-new/product-features.ts
@@ -1,0 +1,201 @@
+import { Product } from "@/utils/type";
+
+export interface ProductTagline {
+  title: string;
+  docsLink: string;
+  consoleLink: string;
+}
+
+/**
+ * Taglines shown above the active product tab. Shared source of truth for the
+ * visible tab header and the crawlable sr-only mirror (product-seo-data.tsx).
+ */
+export const PRODUCT_TAGLINES: Record<Product, ProductTagline> = {
+  [Product.REDIS]: {
+    title: "Serverless Redis in the cloud with low latency and durable storage",
+    docsLink: "https://upstash.com/docs/redis",
+    consoleLink: "https://console.upstash.com/redis",
+  },
+  [Product.VECTOR]: {
+    title: "Serverless Vector database for high-performance search at scale",
+    docsLink: "https://upstash.com/docs/vector",
+    consoleLink: "https://console.upstash.com/vector",
+  },
+  [Product.QSTASH]: {
+    title: "Serverless messaging and scheduling via HTTP",
+    docsLink: "https://upstash.com/docs/qstash",
+    consoleLink: "https://console.upstash.com/qstash",
+  },
+  [Product.WORKFLOW]: {
+    title: "Durable, reliable and performant serverless functions",
+    docsLink: "https://upstash.com/docs/workflow",
+    consoleLink: "https://console.upstash.com/workflow",
+  },
+  [Product.SEARCH]: {
+    title: "Serverless AI search at scale",
+    docsLink: "https://upstash.com/docs/search",
+    consoleLink: "https://console.upstash.com/search",
+  },
+  [Product.BOX]: {
+    title: "Secure cloud containers for AI agents",
+    docsLink: "https://upstash.com/docs/box",
+    consoleLink: "https://console.upstash.com/box",
+  },
+};
+
+export interface ProductFeatureGroup {
+  /**
+   * Title split into lines. The visible tab joins them with a responsive
+   * `<br>`; the sr-only mirror joins them with a space.
+   */
+  title: string[];
+  bullets: string[];
+}
+
+/**
+ * Feature copy for each product tab. Both the visible interactive tab
+ * (hero-tab-*.tsx) and the crawlable sr-only mirror (product-seo-data.tsx)
+ * render from this single source, so search engines and AI crawlers see every
+ * product's content even though the UI only renders the active tab.
+ *
+ * Keep the product order aligned with the tabs in hero-products.tsx.
+ */
+export const PRODUCT_FEATURES: Record<
+  | Product.REDIS
+  | Product.VECTOR
+  | Product.QSTASH
+  | Product.WORKFLOW
+  | Product.BOX,
+  ProductFeatureGroup[]
+> = {
+  [Product.REDIS]: [
+    {
+      title: ["Highly Available,", "Infinitely Scalable"],
+      bullets: [
+        "99.99% uptime guarantee",
+        "Automatic scaling to meet your demands",
+        "No server management required",
+      ],
+    },
+    {
+      title: ["Global", "Low Latency"],
+      bullets: [
+        "Lightning-fast response times worldwide",
+        "Multi-region replication options",
+        "Optimize for your users, wherever they are",
+      ],
+    },
+    {
+      title: ["Persistent Redis,", "In-Memory Speed"],
+      bullets: [
+        "In-memory speed with disk-like persistence",
+        "Data safety without sacrificing performance",
+        "Automatic backups",
+      ],
+    },
+  ],
+  [Product.VECTOR]: [
+    {
+      title: ["Massive", "Scalability"],
+      bullets: [
+        "Handle hundreds of millions of vectors",
+        "Seamless scaling as your data grows",
+        "Maintain performance at any scale",
+      ],
+    },
+    {
+      title: ["Disk-Based", "Algorithm for Efficiency"],
+      bullets: [
+        "Optimize storage and performance",
+        "Cost-effective solution for large datasets",
+        "Balance between speed and resource usage",
+      ],
+    },
+    {
+      title: ["Powerful Metadata", "Store with SQL Support"],
+      bullets: [
+        "Rich querying capabilities with familiar SQL syntax",
+        "Easily combine vector similarity search with metadata filtering",
+        "Flexible data organization and retrieval",
+      ],
+    },
+  ],
+  [Product.QSTASH]: [
+    {
+      title: ["Serverless", "Messaging"],
+      bullets: [
+        "Effortless communication between serverless functions",
+        "Decouple your microservices architecture",
+        "Scale your messaging infrastructure without limits",
+      ],
+    },
+    {
+      title: ["Scheduled Tasks", "with CRON"],
+      bullets: [
+        "Easily set up recurring tasks and jobs",
+        "Flexible scheduling with CRON syntax",
+        "Automate your workflows with precision",
+      ],
+    },
+    {
+      title: ["Intelligent", "Retry Mechanism"],
+      bullets: [
+        "Automatically retry failed tasks",
+        "Ensure task completion in unreliable environments",
+        "Configurable retry policies to suit your needs",
+      ],
+    },
+  ],
+  [Product.WORKFLOW]: [
+    {
+      title: ["Serverless", "Function Orchestration"],
+      bullets: [
+        "Coordinate complex serverless workflows",
+        "Integrate and manage multiple functions with ease",
+        "Streamline your serverless architecture",
+      ],
+    },
+    {
+      title: ["Eliminate", "Function Timeouts"],
+      bullets: [
+        "Execute long-running processes without constraints",
+        "No more arbitrary time limits on your operations",
+        "Focus on your logic, not on timing workarounds",
+      ],
+    },
+    {
+      title: ["Automatic", "Error Recovery"],
+      bullets: [
+        "Built-in resilience for your workflows",
+        "Automatically retry failed steps",
+        "Ensure robust execution even in unpredictable environments",
+      ],
+    },
+  ],
+  [Product.BOX]: [
+    {
+      title: ["Built for AI Agents"],
+      bullets: [
+        "Secure, isolated cloud containers",
+        "Built-in Claude Code and Codex agents",
+        "Full shell, filesystem, and git access",
+      ],
+    },
+    {
+      title: ["Durable & Persistent"],
+      bullets: [
+        "Infinite lifespan with auto freeze/resume",
+        "Persistent storage across sessions",
+        "Usage-based pricing, pay only when active",
+      ],
+    },
+    {
+      title: ["Scales Seamlessly"],
+      bullets: [
+        "Serverless, no infrastructure to manage",
+        "Scale to hundreds of boxes instantly",
+        "Multi-agent orchestration support",
+      ],
+    },
+  ],
+};

--- a/src/components/home/product-new/product-seo-data.tsx
+++ b/src/components/home/product-new/product-seo-data.tsx
@@ -1,0 +1,56 @@
+import { Product } from "@/utils/type";
+import {
+  PRODUCT_FEATURES,
+  PRODUCT_TAGLINES,
+} from "./product-features";
+
+/**
+ * Crawlable, screen-reader-only mirror of the non-default product tabs.
+ *
+ * The interactive product section only renders the tab the user has selected
+ * (default: Redis), so the other products' taglines and feature copy never
+ * reach the server-rendered HTML. This block renders those products from the
+ * same PRODUCT_FEATURES / PRODUCT_TAGLINES source, so search engines and AI
+ * crawlers that fetch the page as HTML still get every product's content.
+ * Redis is omitted because it is the default tab and already in the HTML. It
+ * mirrors content the user can reach by clicking the tabs, so it is not
+ * hidden/deceptive.
+ */
+const SEO_PRODUCTS = [
+  Product.VECTOR,
+  Product.QSTASH,
+  Product.WORKFLOW,
+  Product.BOX,
+] as const;
+
+export default function ProductSeoData() {
+  return (
+    <section className="sr-only">
+      <h2>Upstash Serverless Data Platform — products</h2>
+      {SEO_PRODUCTS.map((product) => (
+        <article key={product}>
+          <h3>
+            {product}: {PRODUCT_TAGLINES[product].title}
+          </h3>
+          {PRODUCT_FEATURES[product].map((group, groupIndex) => (
+            <div key={groupIndex}>
+              <h4>{group.title.join(" ")}</h4>
+              <ul>
+                {group.bullets.map((bullet, bulletIndex) => (
+                  <li key={bulletIndex}>{bullet}</li>
+                ))}
+              </ul>
+            </div>
+          ))}
+          <p>
+            Learn more in the{" "}
+            <a href={PRODUCT_TAGLINES[product].docsLink}>
+              {product} documentation
+            </a>
+            .
+          </p>
+        </article>
+      ))}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
The homepage product section only renders the active tab (default: Redis),
so Vector/QStash/Workflow/Box taglines and feature copy never reached the
server-rendered HTML and were invisible to search engines and AI crawlers.
Verified against the production HTML: the Redis tagline/features were present
but the other products had zero occurrences.

This extracts the tab copy into a single shared source and adds a crawlable
`sr-only` mirror (same pattern as the pricing pages) so every product's content
is in the SSR HTML regardless of which tab is active. Also takes the `/redis`
page title fix from the `dx-2835-redis-landing-seo` branch.

## Changes
- Add `product-features.ts` — single source of truth for product taglines and
  feature copy (`PRODUCT_TAGLINES` / `PRODUCT_FEATURES`).
- Add shared `HeroTabFeatures` renderer; the 5 visible tabs now render from the
  shared data (DOM byte-identical — no visual change).
- Add `product-seo-data.tsx` — unconditional `sr-only` mirror of the
  non-default products (Vector, QStash, Workflow, Box). Redis is omitted since
  it's the default visible tab and already in the HTML.
- Fix `/redis` page title: drop the hardcoded "- Upstash" so it uses the root
  layout's `%s | Upstash` template; set OG/Twitter titles explicitly.

## Testing
- `tsc --noEmit` clean.
- Ran the dev server and confirmed Vector/QStash/Workflow/Box tagline + feature
  text now appear in the rendered HTML (were absent before), the mirror carries
  `class="sr-only"`, the visible Redis tab markup is unchanged, and there are no
  hydration/React-key warnings.

Two commits on the branch:
- bf7227c8 — surface all product tabs to crawlers via sr-only mirror
- 9e764cb9 — fix /redis page title to use brand template