### PR TITLE
fix: redirect URLs with trailing junk text to the real page

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -78,6 +78,18 @@ export function middleware(request: NextRequest, event: NextFetchEvent) {
   }
 
   const pathname = request.nextUrl.pathname;
+
+  // Linkifiers in chat apps fuse our URLs with trailing prose ("see <url> for
+  // details"), producing 404 paths like "/docs/.../max_requests_limit for
+  // details". No real URL on this site contains whitespace, so strip at the
+  // first space and redirect to the intended page.
+  const junkIndex = pathname.search(/ |%20/);
+  if (junkIndex > 0) {
+    const cleanUrl = request.nextUrl.clone();
+    cleanUrl.pathname = pathname.slice(0, junkIndex);
+    return NextResponse.redirect(cleanUrl, 301);
+  }
+
   const userAgent = request.headers.get("user-agent") ?? "";
   const aiAgentMatch = userAgent.match(AI_BOT_REGEX);
   const aiAgent = aiAgentMatch ? aiAgentMatch[0] : null;


### PR DESCRIPTION
## Summary

Chat apps (Slack, ChatGPT, Discord...) turn a URL **and the words after it** into one link. Example: our error message says

```
see https://upstash.com/docs/redis/troubleshooting/max_requests_limit for details
```

and the linkified URL becomes `/docs/redis/troubleshooting/max_requests_limit for details` (with ` for details` inside the path). People click it and land on a 404. That exact broken URL got real visits on 10+ different days in July, and analytics shows many more like it (`/pricing/redis pay as you go calculation`, etc).

No real URL on our site contains a space, so the fix is simple: if the path has a space, cut it there and 301-redirect to the clean part.

Before: `/docs/redis/troubleshooting/max_requests_limit for details` -> 404
After: same URL -> 301 -> `/docs/redis/troubleshooting/max_requests_limit`

## Changes

- `src/middleware.ts`: if the path contains a space (` ` or `%20`), 301-redirect to everything before it. Query params are kept.

## Testing

- `tsc --noEmit` passes.
- Middleware runs before the `/docs` rewrite to Mintlify, so docs URLs are covered too.

https://claude.ai/code/session_014EY1udxW7np54pjqgaHeYh