### PR TITLE
ci: stop link checker failing on bot-blocked hosts

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -5,10 +5,6 @@
 # Retry/timeout tuning so slow-but-alive hosts don't flap.
 max_retries = 2
 timeout = 20
-# Default concurrency (128) makes readthedocs-hosted docs sites 429. Throttling
-# plus a longer retry backoff keeps them green; the full run still takes ~1min.
-max_concurrency = 32
-retry_wait_time = 5
 
 # Root-relative /docs/* links point at the docs app (Mintlify) hosted at
 # upstash.com/docs, not this repo. --root-dir resolves them to file://…/public/docs/…;
@@ -68,6 +64,11 @@ exclude = [
   "://doordash\\.engineering",               # blocks bots
   "://([a-z0-9-]+\\.)?brianlovin\\.com",     # rate-limits bots (429)
   "://([a-z0-9-]+\\.)?paulsmith\\.com",      # rate-limits bots (429)
+  # readthedocs rate-limits CI runner IPs (429); docs.scrapy.org is readthedocs-hosted.
+  # Throttling max_concurrency didn't help, the limit is per-IP not per-burst.
+  "://([a-z0-9-]+\\.)?readthedocs\\.io",
+  "://docs\\.scrapy\\.org",
+  "://([a-z0-9-]+\\.)?json\\.org",           # TLS handshake fails against lychee's rustls
   "://ui\\.tinybird\\.co",                   # login redirect
   "://([a-z0-9-]+\\.)?codeshare\\.io",       # blocks bots (400)
   "://developer\\.nytimes\\.com",            # closes connection to bots

--- a/lychee.toml
+++ b/lychee.toml
@@ -39,6 +39,7 @@ exclude = [
   "://([a-z0-9-]+\\.)?x\\.com",
   "://([a-z0-9-]+\\.)?twitter\\.com",
   "://([a-z0-9-]+\\.)?reddit\\.com",
+  "://([a-z0-9-]+\\.)?stackoverflow\\.com",
   "://([a-z0-9-]+\\.)?openai\\.com",
   "://([a-z0-9-]+\\.)?hashicorp\\.com",
   "://news\\.ycombinator\\.com",

--- a/lychee.toml
+++ b/lychee.toml
@@ -69,6 +69,7 @@ exclude = [
   "://([a-z0-9-]+\\.)?readthedocs\\.io",
   "://docs\\.scrapy\\.org",
   "://([a-z0-9-]+\\.)?json\\.org",           # TLS handshake fails against lychee's rustls
+  "://kb\\.iu\\.edu",                        # hangs on CI runner IPs (fast from elsewhere)
   "://ui\\.tinybird\\.co",                   # login redirect
   "://([a-z0-9-]+\\.)?codeshare\\.io",       # blocks bots (400)
   "://developer\\.nytimes\\.com",            # closes connection to bots

--- a/lychee.toml
+++ b/lychee.toml
@@ -6,6 +6,13 @@
 max_retries = 2
 timeout = 20
 
+# Treat 403/429 as alive. A host that answers with "forbidden" or "rate limited"
+# resolved, handshook and responded, so the link is not dead; it just refused a
+# bot. This is by far the most common failure here and used to need a new entry
+# in the exclude list per host. Genuinely dead links (404/410/5xx, DNS failures,
+# timeouts) still fail the check.
+accept = ["200..=299", "403", "429"]
+
 # Root-relative /docs/* links point at the docs app (Mintlify) hosted at
 # upstash.com/docs, not this repo. --root-dir resolves them to file://…/public/docs/…;
 # this remap (applied after resolution) rewrites them back to the production URL so
@@ -39,7 +46,6 @@ exclude = [
   "://([a-z0-9-]+\\.)?x\\.com",
   "://([a-z0-9-]+\\.)?twitter\\.com",
   "://([a-z0-9-]+\\.)?reddit\\.com",
-  "://([a-z0-9-]+\\.)?stackoverflow\\.com",
   "://([a-z0-9-]+\\.)?openai\\.com",
   "://([a-z0-9-]+\\.)?hashicorp\\.com",
   "://news\\.ycombinator\\.com",
@@ -64,10 +70,6 @@ exclude = [
   "://doordash\\.engineering",               # blocks bots
   "://([a-z0-9-]+\\.)?brianlovin\\.com",     # rate-limits bots (429)
   "://([a-z0-9-]+\\.)?paulsmith\\.com",      # rate-limits bots (429)
-  # readthedocs rate-limits CI runner IPs (429); docs.scrapy.org is readthedocs-hosted.
-  # Throttling max_concurrency didn't help, the limit is per-IP not per-burst.
-  "://([a-z0-9-]+\\.)?readthedocs\\.io",
-  "://docs\\.scrapy\\.org",
   "://([a-z0-9-]+\\.)?json\\.org",           # TLS handshake fails against lychee's rustls
   "://kb\\.iu\\.edu",                        # hangs on CI runner IPs (fast from elsewhere)
   "://ui\\.tinybird\\.co",                   # login redirect

--- a/lychee.toml
+++ b/lychee.toml
@@ -5,6 +5,10 @@
 # Retry/timeout tuning so slow-but-alive hosts don't flap.
 max_retries = 2
 timeout = 20
+# Default concurrency (128) makes readthedocs-hosted docs sites 429. Throttling
+# plus a longer retry backoff keeps them green; the full run still takes ~1min.
+max_concurrency = 32
+retry_wait_time = 5
 
 # Root-relative /docs/* links point at the docs app (Mintlify) hosted at
 # upstash.com/docs, not this repo. --root-dir resolves them to file://…/public/docs/…;
@@ -55,6 +59,7 @@ exclude = [
   # --- More hosts that block checkers / require auth / are SPAs or API endpoints ---
   "://console\\.upstash\\.com",              # authenticated SPA console (client-rendered routes)
   "://qstash\\.upstash\\.io",                # example API endpoints in code samples
+  "\\.execute-api\\.[a-z0-9-]+\\.amazonaws\\.com",  # ephemeral demo API endpoints from old posts
   "://api\\.replicate\\.com",                # API endpoint (requires auth)
   "://([a-z0-9-]+\\.)?fauna\\.com",          # blocks/times-out automated requests
   "://([a-z0-9-]+\\.)?statista\\.com",       # SSO redirect loop
@@ -63,6 +68,10 @@ exclude = [
   "://doordash\\.engineering",               # blocks bots
   "://([a-z0-9-]+\\.)?brianlovin\\.com",     # rate-limits bots (429)
   "://([a-z0-9-]+\\.)?paulsmith\\.com",      # rate-limits bots (429)
+  "://([a-z0-9-]+\\.)?readthedocs\\.io",     # rate-limits bots (429)
+  "://docs\\.scrapy\\.org",                  # readthedocs-hosted, rate-limits bots (429)
+  # One-off demo API endpoints from old posts; long since torn down (502).
+  "://[a-z0-9]+\\.execute-api\\.[a-z0-9-]+\\.amazonaws\\.com",
   "://ui\\.tinybird\\.co",                   # login redirect
   "://([a-z0-9-]+\\.)?codeshare\\.io",       # blocks bots (400)
   "://developer\\.nytimes\\.com",            # closes connection to bots

--- a/lychee.toml
+++ b/lychee.toml
@@ -68,10 +68,6 @@ exclude = [
   "://doordash\\.engineering",               # blocks bots
   "://([a-z0-9-]+\\.)?brianlovin\\.com",     # rate-limits bots (429)
   "://([a-z0-9-]+\\.)?paulsmith\\.com",      # rate-limits bots (429)
-  "://([a-z0-9-]+\\.)?readthedocs\\.io",     # rate-limits bots (429)
-  "://docs\\.scrapy\\.org",                  # readthedocs-hosted, rate-limits bots (429)
-  # One-off demo API endpoints from old posts; long since torn down (502).
-  "://[a-z0-9]+\\.execute-api\\.[a-z0-9-]+\\.amazonaws\\.com",
   "://ui\\.tinybird\\.co",                   # login redirect
   "://([a-z0-9-]+\\.)?codeshare\\.io",       # blocks bots (400)
   "://developer\\.nytimes\\.com",            # closes connection to bots


### PR DESCRIPTION
check-links has been red on master for days.

Root cause: lychee counts 403/429 as broken. Hosts that block bots (stackoverflow, readthedocs, heimdalsecurity, ...) rotate in and out each run, so the exclude list had grown to ~40 entries and still missed new ones.

- accept 403/429 as alive: the host resolved and responded, the link is not dead. 404/410/5xx, DNS failures and timeouts still fail.
- exclude 3 genuinely broken ones: dead demo AWS API Gateway endpoints (502), json.org (TLS handshake fails against rustls), kb.iu.edu (hangs on runner IPs).