### PR TITLE
fix: replace dead links failing the nightly link check

### DIFF
--- a/data/blog/2021-11-01-cloudflare-workers-waiting-room.mdx
+++ b/data/blog/2021-11-01-cloudflare-workers-waiting-room.mdx
@@ -10,7 +10,7 @@ In this blog post, we will implement a waiting room page for your website.
 
 ### Why?
 
-A high number of visitors on your website is generally a good thing but not always. Sudden high traffic may easily overwhelm your applications which may disrupt your services completely. A waiting room is a solution that helps you control the traffic and protect your resources during traffic surges. [Cloudflare Waiting Room](https://www.cloudflare.com/waiting-room/) is a good solution but it is only available for business and enterprise accounts. Don't worry, in this blog we will build a waiting room for any type of website using Cloudflare Workers and Upstash Redis.
+A high number of visitors on your website is generally a good thing but not always. Sudden high traffic may easily overwhelm your applications which may disrupt your services completely. A waiting room is a solution that helps you control the traffic and protect your resources during traffic surges. [Cloudflare Waiting Room](https://www.cloudflare.com/products/waiting-room/) is a good solution but it is only available for business and enterprise accounts. Don't worry, in this blog we will build a waiting room for any type of website using Cloudflare Workers and Upstash Redis.
 
 ### How?
 

--- a/data/blog/2022-04-19-kafka-url-shortener.mdx
+++ b/data/blog/2022-04-19-kafka-url-shortener.mdx
@@ -6,9 +6,9 @@ authors:
 tags: [serverless, kafka, materialize]
 ---
 
-This is a Node.js URL shortener app that uses [Cloudflare Workers](https://www.cloudflare.com/workers/).
+This is a Node.js URL shortener app that uses [Cloudflare Workers](https://www.cloudflare.com/products/workers/).
 
-The app is powered by [Cloudflare Workers](https://www.cloudflare.com/workers/) and [Upstash](https://upstash.com/) Redis® for storing data and Kafka for storing the click events along with [Materialize](https://materialize.com/) for real-time data analytics.
+The app is powered by [Cloudflare Workers](https://www.cloudflare.com/products/workers/) and [Upstash](https://upstash.com/) Redis® for storing data and Kafka for storing the click events along with [Materialize](https://materialize.com/) for real-time data analytics.
 
 [Upstash](https://upstash.com/) offers Serverless, Low latency, and pay-as-you-go solutions for Kafka and Redis.
 

--- a/data/blog/2026-08-07-context7-portable-agent-plugin.mdx
+++ b/data/blog/2026-08-07-context7-portable-agent-plugin.mdx
@@ -92,7 +92,7 @@ The spec also says nothing about distribution, sandboxing, permissions, or publi
 
 ## How to install the Context7 Agent Plugin
 
-The plugin lives in the [Context7 repository](https://github.com/upstash/context7) under `plugins/agent-plugins/context7`. The easiest way to install it is the [plugins CLI](https://github.com/vercel-labs/plugins), which discovers plugins in a repo, detects which agent tools you have installed, and installs into them:
+The plugin lives in the [Context7 repository](https://github.com/upstash/context7) under `plugins/agent-plugins/context7`. The easiest way to install it is the [plugins CLI](https://www.npmjs.com/package/plugins), which discovers plugins in a repo, detects which agent tools you have installed, and installs into them:
 
 ```bash
 npx plugins add upstash/context7


### PR DESCRIPTION
Two dead links failing the nightly link check:

- 3x `www.cloudflare.com/{workers,waiting-room}/` -> resolved `/products/` URLs (old ones redirect, final hop flakes with an HTTP/2 error).
- `github.com/vercel-labs/plugins` is a hard 404 -> npm package page.

lychee 0.24.2 on the 3 changed files: 38/38 OK.