### PR TITLE
feat: /ask endpoint answering site questions from Upstash Search

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "@rehype-pretty/transformers": "^0.13.2",
     "@tabler/icons-react": "^3.30.0",
     "@upstash/claps": "^1.0.0-beta.5",
+    "@upstash/redis": "^1.38.2",
+    "@upstash/search": "^0.1.7",
     "@vercel/analytics": "^2.0.1",
     "@vercel/functions": "^1.5.1",
     "@vercel/og": "^0.6.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,12 @@ importers:
       '@upstash/claps':
         specifier: ^1.0.0-beta.5
         version: 1.0.0-beta.5(@types/node@22.13.2)
+      '@upstash/redis':
+        specifier: ^1.38.2
+        version: 1.38.2
+      '@upstash/search':
+        specifier: ^0.1.7
+        version: 0.1.7
       '@vercel/analytics':
         specifier: ^2.0.1
         version: 2.0.1(next@16.2.12(@types/node@22.13.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
@@ -1368,6 +1374,15 @@ packages:
 
   '@upstash/redis@1.34.3':
     resolution: {integrity: sha512-VT25TyODGy/8ljl7GADnJoMmtmJ1F8d84UXfGonRRF8fWYJz7+2J6GzW+a6ETGtk4OyuRTt7FRSvFG5GvrfSdQ==}
+
+  '@upstash/redis@1.38.2':
+    resolution: {integrity: sha512-RZ+JaRCVIS+ZTGnjOnDMr+/0aqDxsBb5rV6aW+Pys4SGELwr5lwE3UbLHRCHqMQ5Ulxj0b/CFBHfbmE175Otog==}
+
+  '@upstash/search@0.1.7':
+    resolution: {integrity: sha512-rgJ52TP0eUPLFo4K6TZtiC7qICbJnEwkT+TqaDI1vN8/Hk6qidgNC9dpnUUXCiqfwogty1rlSyBhYfk6PRgXjA==}
+
+  '@upstash/vector@1.2.3':
+    resolution: {integrity: sha512-yXsWKeuHNYyH72BcSZd3bV5ZD5MybAoTvKxkMaeV2UzuGfNzbHBVh5eO+ysTWTFAf8I9XcOueF4tZfAGjCa4Iw==}
 
   '@vercel/analytics@2.0.1':
     resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
@@ -2791,6 +2806,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
@@ -3971,6 +3989,16 @@ snapshots:
   '@upstash/redis@1.34.3':
     dependencies:
       crypto-js: 4.2.0
+
+  '@upstash/redis@1.38.2':
+    dependencies:
+      uncrypto: 0.1.3
+
+  '@upstash/search@0.1.7':
+    dependencies:
+      '@upstash/vector': 1.2.3
+
+  '@upstash/vector@1.2.3': {}
 
   '@vercel/analytics@2.0.1(next@16.2.12(@types/node@22.13.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
     optionalDependencies:
@@ -5738,6 +5766,8 @@ snapshots:
   tslib@2.8.1: {}
 
   typescript@5.7.3: {}
+
+  uncrypto@0.1.3: {}
 
   undici-types@6.20.0: {}
 

--- a/src/app/ask/log.ts
+++ b/src/app/ask/log.ts
@@ -1,0 +1,27 @@
+import { Redis } from "@upstash/redis";
+import { waitUntil } from "@vercel/functions";
+
+// Counts every question /ask receives in one sorted set, member = normalized
+// question, score = times asked. Write-only from the app: read it in the
+// Upstash console.
+const KEY = "ask:questions";
+const MEMBER_LIMIT = 200;
+
+const redis =
+  process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN
+    ? Redis.fromEnv()
+    : null;
+
+export function normalizeQuestion(q: string): string {
+  return q.trim().toLowerCase().replace(/\s+/g, " ").slice(0, MEMBER_LIMIT);
+}
+
+/** Fire-and-forget: never delays or fails the request it logs. */
+export function logQuestion(q: string) {
+  if (!redis) return;
+  waitUntil(
+    redis.zincrby(KEY, 1, normalizeQuestion(q)).catch((error) => {
+      console.error("Failed to log /ask question:", error);
+    }),
+  );
+}

--- a/src/app/ask/log.ts
+++ b/src/app/ask/log.ts
@@ -1,22 +1,16 @@
 import { Redis } from "@upstash/redis";
 import { waitUntil } from "@vercel/functions";
 
-// Counts every question /ask receives in one sorted set, member = normalized
-// question, score = times asked. Write-only from the app: read it in the
-// Upstash console.
 const KEY = "ask:questions";
-const MEMBER_LIMIT = 200;
 
-// Own env names: UPSTASH_REDIS_REST_* is already taken by the claps database.
 const url = process.env.UPSTASH_REDIS_SEARCH_DATA_URL;
 const token = process.env.UPSTASH_REDIS_SEARCH_DATA_TOKEN;
 const redis = url && token ? new Redis({ url, token }) : null;
 
 export function normalizeQuestion(q: string): string {
-  return q.trim().toLowerCase().replace(/\s+/g, " ").slice(0, MEMBER_LIMIT);
+  return q.trim().toLowerCase().replace(/\s+/g, " ");
 }
 
-/** Fire-and-forget: never delays or fails the request it logs. */
 export function logQuestion(q: string) {
   if (!redis) return;
   waitUntil(

--- a/src/app/ask/log.ts
+++ b/src/app/ask/log.ts
@@ -7,10 +7,10 @@ import { waitUntil } from "@vercel/functions";
 const KEY = "ask:questions";
 const MEMBER_LIMIT = 200;
 
-const redis =
-  process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN
-    ? Redis.fromEnv()
-    : null;
+// Own env names: UPSTASH_REDIS_REST_* is already taken by the claps database.
+const url = process.env.UPSTASH_REDIS_SEARCH_DATA_URL;
+const token = process.env.UPSTASH_REDIS_SEARCH_DATA_TOKEN;
+const redis = url && token ? new Redis({ url, token }) : null;
 
 export function normalizeQuestion(q: string): string {
   return q.trim().toLowerCase().replace(/\s+/g, " ").slice(0, MEMBER_LIMIT);

--- a/src/app/ask/route.ts
+++ b/src/app/ask/route.ts
@@ -1,0 +1,90 @@
+import { Search } from "@upstash/search";
+import { NextResponse, type NextRequest } from "next/server";
+import { logQuestion } from "./log";
+
+// GET /ask?q=<question>[&limit=5]
+//
+// Answers a natural-language question about upstash.com with the best-matching
+// page passages from the `upstash-site` Upstash Search index (built by
+// crawling the sitemap; one document per page section).
+
+const INDEX_NAME = "upstash-site";
+const DEFAULT_LIMIT = 5;
+const MAX_LIMIT = 20;
+
+type Content = {
+  title: string;
+  section: string;
+  text: string;
+  kind: string;
+};
+
+type Metadata = {
+  url: string;
+  path: string;
+  kind: string;
+  title: string;
+  description: string;
+  publishedAt: string | null;
+  chunk: number;
+  chunks: number;
+};
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: NextRequest) {
+  const q = req.nextUrl.searchParams.get("q")?.trim();
+  if (!q) {
+    return NextResponse.json(
+      { error: "missing q", usage: "/ask?q=how+is+qstash+priced" },
+      { status: 400 },
+    );
+  }
+
+  const rawLimit = req.nextUrl.searchParams.get("limit");
+  const parsedLimit = rawLimit === null ? NaN : Number(rawLimit);
+  const limit = Number.isInteger(parsedLimit)
+    ? Math.min(Math.max(parsedLimit, 1), MAX_LIMIT)
+    : DEFAULT_LIMIT;
+
+  const url = process.env.UPSTASH_SEARCH_REST_URL;
+  const token = process.env.UPSTASH_SEARCH_REST_TOKEN;
+  if (!url || !token) {
+    return NextResponse.json(
+      { error: "search is not configured" },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const index = new Search({ url, token }).index<Content, Metadata>(
+      INDEX_NAME,
+    );
+    const hits = await index.search({
+      query: q,
+      limit,
+      reranking: true,
+      // The default query enrichment rewrites product names ("upstash box")
+      // into generic phrasing and buries the right pages.
+      inputEnrichment: false,
+    });
+
+    logQuestion(q);
+
+    return NextResponse.json({
+      question: q,
+      results: hits.map((hit) => ({
+        title: hit.content.title,
+        section: hit.content.section || null,
+        text: hit.content.text,
+        kind: hit.content.kind,
+        url: hit.metadata?.url ?? null,
+        publishedAt: hit.metadata?.publishedAt ?? null,
+        score: hit.score,
+      })),
+    });
+  } catch (error) {
+    console.error("/ask search failed:", error);
+    return NextResponse.json({ error: "search failed" }, { status: 502 });
+  }
+}

--- a/src/app/ask/route.ts
+++ b/src/app/ask/route.ts
@@ -2,12 +2,6 @@ import { Search } from "@upstash/search";
 import { NextResponse, type NextRequest } from "next/server";
 import { logQuestion } from "./log";
 
-// GET /ask?q=<question>[&limit=5]
-//
-// Answers a natural-language question about upstash.com with the best-matching
-// page passages from the `upstash-site` Upstash Search index (built by
-// crawling the sitemap; one document per page section).
-
 const INDEX_NAME = "upstash-site";
 const DEFAULT_LIMIT = 5;
 const MAX_LIMIT = 20;
@@ -64,8 +58,6 @@ export async function GET(req: NextRequest) {
       query: q,
       limit,
       reranking: true,
-      // The default query enrichment rewrites product names ("upstash box")
-      // into generic phrasing and buries the right pages.
       inputEnrichment: false,
     });
 


### PR DESCRIPTION
## What

`GET /ask?q=<question>[&limit=1..20]` answers natural-language questions about upstash.com from the `upstash-site` Upstash Search index and returns, per hit:

```json
{ "title", "section", "text", "kind", "url", "publishedAt", "score" }
```

The index is built from `sitemap-0.xml` (home, product, pricing, customers, careers, enterprise pages and the 355 blog posts; docs, `/examples`, and blog author/tag/feed listings excluded), one document per page section.

Every answered question is counted in the `ask:questions` sorted set (`ZINCRBY`, fire-and-forget via `waitUntil`) on a dedicated Redis, so we can see what agents ask. There is deliberately no read endpoint; view the set in the console.

## Why the search settings

`reranking: true` and `inputEnrichment: false`. The default query enrichment rewrote product names ("upstash box") into generic phrasing and returned the contact page; with enrichment off the Box posts rank first, and reranking puts the "What is Upstash Box?" section on top.

## Responses

- `400` missing `q` (with a usage hint)
- `503` search env vars not set
- `502` search call failed
- `limit` clamps to 1..20, default 5

## Env vars (Vercel)

```
UPSTASH_SEARCH_REST_URL
UPSTASH_SEARCH_REST_TOKEN
UPSTASH_REDIS_SEARCH_DATA_URL
UPSTASH_REDIS_SEARCH_DATA_TOKEN
```

Redis vars use their own names because `UPSTASH_REDIS_REST_*` is already the claps database. Redis is optional: without it the endpoint works and just doesn't count questions.

## Tested locally

- `what is upstash box` → "What is Upstash Box?" section of the Claude Code sandbox post, then the Box launch post
- `how much does qstash cost per message` → QStash Pricing › Pay as You Go
- no `q` → 400; `limit=abc` → 5 results; `limit=99` → 20
- three calls with the same question in different casing/whitespace → one sorted-set member with score 3
