### PR TITLE
ask: advertise /ask via robots, markdown headers and 404

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -5,6 +5,8 @@ Allow: /
 # *
 User-agent: *
 Allow: /
+Allow: /ask
+Allow: /ask?*
 Disallow: /*?
 Disallow: /*%
 Disallow: /v1*

--- a/src/app/404.md/route.ts
+++ b/src/app/404.md/route.ts
@@ -1,0 +1,13 @@
+import { notFoundMarkdown } from "@/lib/ask";
+
+export const dynamic = "force-dynamic";
+
+export function GET() {
+  return new Response(notFoundMarkdown(), {
+    status: 404,
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Vary: "Accept",
+    },
+  });
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,55 @@
+import Bg from "@/components/bg";
+import Button from "@/components/button";
+import Container from "@/components/container";
+import PageHeaderDesc from "@/components/page-header-desc";
+import PageHeaderTitle from "@/components/page-header-title";
+import { negotiate } from "@/lib/accept";
+import { ASK_EXAMPLE, ASK_URL } from "@/lib/ask";
+import { headers } from "next/headers";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+
+export default async function NotFound() {
+  const accept = (await headers()).get("accept") ?? "";
+  if (negotiate(accept) === "markdown") {
+    redirect("/404.md");
+  }
+
+  return (
+    <main className="relative z-0 py-16 text-center md:py-24">
+      <Bg />
+
+      <Container className="max-w-screen-md">
+        <header>
+          <PageHeaderTitle>Page not found</PageHeaderTitle>
+          <PageHeaderDesc className="mt-2">
+            This page does not exist or has moved.
+          </PageHeaderDesc>
+        </header>
+
+        <div className="mt-10 flex flex-wrap justify-center gap-3">
+          <Button asChild variant="primary">
+            <Link href="/">Home</Link>
+          </Button>
+          <Button asChild>
+            <Link href="/docs">Docs</Link>
+          </Button>
+          <Button asChild>
+            <Link href="/blog">Blog</Link>
+          </Button>
+        </div>
+
+        <p className="mt-16 text-balance opacity-60">
+          Looking for something specific? Ask the site in plain language and get
+          the best matching sections as JSON.
+        </p>
+        <a
+          href={ASK_EXAMPLE}
+          className="mt-2 inline-block font-mono text-sm underline opacity-60 hover:opacity-100"
+        >
+          {ASK_URL}
+        </a>
+      </Container>
+    </main>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,10 +1,10 @@
 import Bg from "@/components/bg";
+import { SITE_URL } from "@/utils/const";
 import Button from "@/components/button";
 import Container from "@/components/container";
 import PageHeaderDesc from "@/components/page-header-desc";
 import PageHeaderTitle from "@/components/page-header-title";
 import { negotiate } from "@/lib/accept";
-import { ASK_EXAMPLE, ASK_URL } from "@/lib/ask";
 import { headers } from "next/headers";
 import Link from "next/link";
 import { redirect } from "next/navigation";
@@ -40,15 +40,17 @@ export default async function NotFound() {
         </div>
 
         <p className="mt-16 text-balance opacity-60">
-          Looking for something specific? Ask the site in plain language and get
-          the best matching sections as JSON.
+          Looking for something specific? Just use our answer index, for example:
         </p>
-        <a
+        <a href="https://upstash.com/ask?q=compare+upstash+redis+to+elasticache" className="mt-4 text-balance opacity-100 underline">
+          https://upstash.com/ask?q=compare+upstash+redis+to+elasticache
+        </a>
+        {/* <a
           href={ASK_EXAMPLE}
           className="mt-2 inline-block font-mono text-sm underline opacity-60 hover:opacity-100"
         >
           {ASK_URL}
-        </a>
+        </a> */}
       </Container>
     </main>
   );

--- a/src/app/pricing/box.md/route.ts
+++ b/src/app/pricing/box.md/route.ts
@@ -1,3 +1,4 @@
+import { ASK_MARKDOWN_LINE } from "@/lib/ask";
 import {
   BOX_ALL_PLANS,
   BOX_FAQ,
@@ -13,6 +14,7 @@ function generateMarkdown(): string {
     "",
     "> **Source:** https://upstash.com/pricing/box",
     "> **Format:** text/markdown — machine-readable pricing for agents and LLMs",
+    ASK_MARKDOWN_LINE,
     "> **Contact:** sales@upstash.com (Enterprise) · support@upstash.com (Support)",
     "",
     "Upstash Box is a serverless compute platform. Standard boxes auto-pause when idle (no CPU charges).",

--- a/src/app/pricing/qstash.md/route.ts
+++ b/src/app/pricing/qstash.md/route.ts
@@ -1,3 +1,4 @@
+import { ASK_MARKDOWN_LINE } from "@/lib/ask";
 import {
   QSTASH_ALL_PLANS,
   QSTASH_ENTERPRISE_PLAN,
@@ -32,6 +33,7 @@ function generateMarkdown(): string {
     "",
     "> **Source:** https://upstash.com/pricing/qstash",
     "> **Format:** text/markdown — machine-readable pricing for agents and LLMs",
+    ASK_MARKDOWN_LINE,
     "> **Contact:** sales@upstash.com (Enterprise) · support@upstash.com (Support)",
     "",
     "QStash is a serverless message queue and scheduler. You are only charged for messages — retries are free.",

--- a/src/app/pricing/redis.md/route.ts
+++ b/src/app/pricing/redis.md/route.ts
@@ -1,3 +1,4 @@
+import { ASK_MARKDOWN_LINE } from "@/lib/ask";
 import {
   REDIS_ALL_PLANS,
   REDIS_ENTERPRISE_PLAN,
@@ -58,6 +59,7 @@ function generateMarkdown(): string {
     "",
     "> **Source:** https://upstash.com/pricing/redis",
     "> **Format:** text/markdown — machine-readable pricing for agents and LLMs",
+    ASK_MARKDOWN_LINE,
     "> **Contact:** sales@upstash.com (Enterprise) · support@upstash.com (Support)",
     "",
     "---",

--- a/src/app/pricing/search.md/route.ts
+++ b/src/app/pricing/search.md/route.ts
@@ -1,3 +1,4 @@
+import { ASK_MARKDOWN_LINE } from "@/lib/ask";
 import {
   SEARCH_ALL_PLANS,
   SEARCH_FAQ,
@@ -13,6 +14,7 @@ function generateMarkdown(): string {
     "",
     "> **Source:** https://upstash.com/pricing/search",
     "> **Format:** text/markdown — machine-readable pricing for agents and LLMs",
+    ASK_MARKDOWN_LINE,
     "> **Contact:** support@upstash.com",
     "",
     `> **Note:** ${SEARCH_NOTE}`,

--- a/src/app/pricing/vector.md/route.ts
+++ b/src/app/pricing/vector.md/route.ts
@@ -1,3 +1,4 @@
+import { ASK_MARKDOWN_LINE } from "@/lib/ask";
 import {
   VECTOR_ALL_PLANS,
   VECTOR_FAQ,
@@ -12,6 +13,7 @@ function generateMarkdown(): string {
     "",
     "> **Source:** https://upstash.com/pricing/vector",
     "> **Format:** text/markdown — machine-readable pricing for agents and LLMs",
+    ASK_MARKDOWN_LINE,
     "> **Contact:** sales@upstash.com (Enterprise) · support@upstash.com (Support)",
     "",
     "Upstash Vector is a serverless vector database for AI and similarity search workloads.",

--- a/src/app/pricing/workflow.md/route.ts
+++ b/src/app/pricing/workflow.md/route.ts
@@ -1,3 +1,4 @@
+import { ASK_MARKDOWN_LINE } from "@/lib/ask";
 import {
   WORKFLOW_ALL_PLANS,
   WORKFLOW_ENTERPRISE_PLAN,
@@ -21,6 +22,7 @@ function generateMarkdown(): string {
     "",
     "> **Source:** https://upstash.com/pricing/workflow",
     "> **Format:** text/markdown — machine-readable pricing for agents and LLMs",
+    ASK_MARKDOWN_LINE,
     "> **Contact:** sales@upstash.com (Enterprise) · support@upstash.com (Support)",
     "",
     "Upstash Workflow enables durable, serverless workflow execution built on top of QStash.",

--- a/src/lib/ask.ts
+++ b/src/lib/ask.ts
@@ -1,9 +1,26 @@
 import { SITE_URL } from "@/utils/const";
 
-export const ASK_URL = `${SITE_URL}/ask?q=your+question`;
-export const ASK_EXAMPLE = `${SITE_URL}/ask?q=how+is+qstash+priced`;
+const ASK_EXAMPLES = [
+  "how is redis priced",
+  "how is upstash box priced",
+  "what is the redis free tier",
+  "compare upstash redis to elasticache",
+  "does upstash support hipaa",
+  "what regions does upstash support",
+  "how to use upstash with vercel",
+  "how to use upstash from cloudflare workers",
+];
 
-export const ASK_MARKDOWN_LINE = `> **Ask:** ${ASK_URL} searches this site in natural language and returns the best matching sections as JSON (title, text, url, publishedAt). Example: ${ASK_EXAMPLE}`;
+function askUrl(question: string): string {
+  return `${SITE_URL}/ask?q=${question.replace(/ /g, "+")}`;
+}
+
+export const ASK_MARKDOWN_LINE = [
+  `> **Ask:** Use ${SITE_URL}/ask?q=your+question to search the Upstash answer index (docs, pricing, blog, product pages). Returns relevant pages with title, text, url, and publishedAt.`,
+  `>`,
+  `> Examples:`,
+  ...ASK_EXAMPLES.map((question) => `> ${askUrl(question)}`),
+].join("\n");
 
 export function notFoundMarkdown(): string {
   return [
@@ -12,12 +29,7 @@ export function notFoundMarkdown(): string {
     "This page does not exist.",
     "",
     "To find something specific on this site (products, pricing, limits, blog posts), ask it directly:",
-    "",
-    `    ${ASK_URL}`,
-    "",
-    `Example: ${ASK_EXAMPLE}`,
-    "",
-    "The response is JSON: the best matching page sections with title, text, kind, url and publishedAt.",
+    `${ASK_MARKDOWN_LINE}`,
     "",
     "Other entry points:",
     "",

--- a/src/lib/ask.ts
+++ b/src/lib/ask.ts
@@ -1,0 +1,29 @@
+import { SITE_URL } from "@/utils/const";
+
+export const ASK_URL = `${SITE_URL}/ask?q=your+question`;
+export const ASK_EXAMPLE = `${SITE_URL}/ask?q=how+is+qstash+priced`;
+
+export const ASK_MARKDOWN_LINE = `> **Ask:** ${ASK_URL} searches this site in natural language and returns the best matching sections as JSON (title, text, url, publishedAt). Example: ${ASK_EXAMPLE}`;
+
+export function notFoundMarkdown(): string {
+  return [
+    "# 404 Not Found",
+    "",
+    "This page does not exist.",
+    "",
+    "To find something specific on this site (products, pricing, limits, blog posts), ask it directly:",
+    "",
+    `    ${ASK_URL}`,
+    "",
+    `Example: ${ASK_EXAMPLE}`,
+    "",
+    "The response is JSON: the best matching page sections with title, text, kind, url and publishedAt.",
+    "",
+    "Other entry points:",
+    "",
+    `- ${SITE_URL}/llms.txt`,
+    `- ${SITE_URL}/docs`,
+    `- ${SITE_URL}/blog.md`,
+    "",
+  ].join("\n");
+}

--- a/src/lib/blog-markdown.ts
+++ b/src/lib/blog-markdown.ts
@@ -1,3 +1,4 @@
+import { ASK_MARKDOWN_LINE } from "@/lib/ask";
 import type { Post } from "@content";
 import { allPosts } from "@content";
 import { SITE_URL } from "@/utils/const";
@@ -12,6 +13,7 @@ export function renderIndex(): string {
     "",
     `> **Source:** ${SITE_URL}/blog`,
     "> **Format:** text/markdown — machine-readable blog index for agents and LLMs",
+    ASK_MARKDOWN_LINE,
     "",
     "---",
     "",
@@ -46,6 +48,7 @@ export function renderPost(post: Post): string {
     `> **Reading time:** ${post.readingTime}`,
     `> **Tags:** ${post.tags.join(", ")}`,
     "> **Format:** text/markdown — machine-readable content for agents and LLMs",
+    ASK_MARKDOWN_LINE,
     "",
     ...(post.description ? [post.description, ""] : []),
     "---",


### PR DESCRIPTION
Follow-up to #610. Makes `/ask` discoverable where agents actually look.

Background: in the Fernpad experiment, every agent that used `/ask` found it in the body of a page it had already fetched, never in `llms.txt` or the sitemap. So the hint goes into the content surfaces themselves.

## Changes

**robots.txt**: `Disallow: /*?` was blocking every `/ask?q=...` URL for robots-respecting crawlers (GPTBot, OAI-SearchBot, ClaudeBot, PerplexityBot). Added `Allow: /ask` and `Allow: /ask?*` ahead of it.

**Markdown surfaces**: `/blog.md`, `/blog/<slug>.md` and the six `/pricing/<product>.md` routes (and their `Accept: text/markdown` negotiated twins) get one line in the header block, right after the H1 so it survives truncation:

```
> **Ask:** https://upstash.com/ask?q=your+question searches this site in natural language and returns the best matching sections as JSON (title, text, url, publishedAt). Example: https://upstash.com/ask?q=how+is+qstash+priced
```

**404**: there was no `not-found.tsx`; unmatched URLs rendered the stock Next 404 inside the layout. Now:
- browsers get a designed 404 (status 404) with Home / Docs / Blog and the `/ask` hint
- clients whose `Accept` prefers `text/markdown` (Cursor, OpenCode, Claude-SearchBot) are redirected once to `/404.md`, which returns the 404 as real `text/markdown` with the hint and entry points
- same `negotiate()` as blog and pricing, so tie-breaking behaves identically site-wide

`notFound()` inside a route handler returns an empty 404 in Next, so a catch-all route handler could not serve the React page; the redirect from `not-found.tsx` is what keeps both paths on Next primitives.

## Verified locally

| request | result |
|---|---|
| `GET /does-not-exist` (browser Accept) | `404 text/html`, designed page, hint present |
| `GET /does-not-exist` `Accept: text/markdown` | `307 /404.md` → `404 text/markdown` |
| `GET /x/y/z` Cursor Accept | `404 text/markdown` |
| `GET /does-not-exist` Claude Code Accept (`text/markdown, text/html, */*`, tie) | `404 text/html` |
| `/`, `/about`, `/pricing/redis`, `/blog`, `/docs/...`, `/ask?q=...`, `/sitemap.xml` | unchanged |
| all seven markdown surfaces | Ask line present once |

No env changes.
