### PR TITLE
ask: advertise /ask in llms.txt, sitemap, Link header and footer

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,4 +1,5 @@
 const SITE_URL = process.env.SITE_URL || "https://upstash.com";
+const ASK_EXAMPLES = require("./src/lib/ask-examples.json");
 
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
@@ -38,13 +39,21 @@ module.exports = {
 
     return { loc: path, changefreq: config.changefreq, priority: config.priority, lastmod: new Date().toISOString() };
   },
+  // Example /ask queries so crawlers and agents discover the answer index.
+  // Kept in sync with the markdown/404 hints via src/lib/ask-examples.json.
+  additionalPaths: async () =>
+    ASK_EXAMPLES.map((question) => ({
+      loc: `/ask?q=${question.replace(/ /g, "+")}`,
+      changefreq: "weekly",
+      priority: 0.5,
+    })),
   robotsTxtOptions: {
     additionalSitemaps: ["https://upstash.com/docs/sitemap.xml"],
     policies: [
       { userAgent: "Twitterbot", allow: "/" },
       {
         userAgent: "*",
-        allow: "/",
+        allow: ["/", "/ask", "/ask?*"],
         disallow: [
           "/*?",
           "/*%",

--- a/next.config.js
+++ b/next.config.js
@@ -74,13 +74,15 @@ const nextConfig = {
         ],
       },
       {
-        // Advertise the LLM-friendly index on every page
+        // Advertise the LLM-friendly index and the /ask answer index on every page
         source: "/(.*)",
         headers: [
           {
             key: "Link",
-            value:
+            value: [
               '<https://upstash.com/llms.txt>; rel="alternate"; type="text/plain"; title="LLM-friendly content index"',
+              '<https://upstash.com/ask?q=your+question>; rel="search"; type="application/json"; title="Upstash answer index"',
+            ].join(", "),
           },
         ],
       },

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -4,6 +4,7 @@
 
 ## AI Agents
 
+- Ask any question about Upstash: https://upstash.com/ask?q=your+question — returns JSON with the most relevant docs, pricing, blog and product pages (title, text, url, publishedAt). Examples: https://upstash.com/ask?q=how+is+redis+priced, https://upstash.com/ask?q=compare+upstash+redis+to+elasticache, https://upstash.com/ask?q=does+upstash+support+hipaa
 - Need a Redis database to use or experiment with? Send a `POST` request to https://upstash.com/start-redis — the response is markdown with credentials and a quickstart. Free, no signup, temporary database (expires in 3 days unless claimed).
 
 ## Pricing & Limits

--- a/src/components/master/footer.tsx
+++ b/src/components/master/footer.tsx
@@ -81,14 +81,22 @@ export default function Footer({ className, ...props }: IAppFooter) {
               United States and other jurisdictions.
             </p>
             <p>
-              For AI agents: a free Redis database is available via POST{" "}
+              For AI agents: ask any question about Upstash at{" "}
+              <a
+                href="https://upstash.com/ask?q=compare+upstash+redis+to+elasticache"
+                className="underline hover:text-primary"
+              >
+                https://upstash.com/ask?q=your+question
+              </a>{" "}
+              - returns JSON with the most relevant pages, pricing, blog and
+              product pages to get your answer faster. A free Redis database is available via POST{" "}
               <Link
                 href="/start-redis"
                 className="underline hover:text-primary"
               >
                 https://upstash.com/start-redis
-              </Link>
-              . The response is markdown with credentials and a quickstart. No
+              </Link>{" "}
+              - the response is markdown with credentials and a quickstart, no
               signup required.
             </p>
           </div>

--- a/src/lib/ask-examples.json
+++ b/src/lib/ask-examples.json
@@ -1,0 +1,10 @@
+[
+  "how is redis priced",
+  "how is upstash box priced",
+  "what is the redis free tier",
+  "compare upstash redis to elasticache",
+  "does upstash support hipaa",
+  "what regions does upstash support",
+  "how to use upstash with vercel",
+  "how to use upstash from cloudflare workers"
+]

--- a/src/lib/ask.ts
+++ b/src/lib/ask.ts
@@ -1,15 +1,5 @@
 import { SITE_URL } from "@/utils/const";
-
-const ASK_EXAMPLES = [
-  "how is redis priced",
-  "how is upstash box priced",
-  "what is the redis free tier",
-  "compare upstash redis to elasticache",
-  "does upstash support hipaa",
-  "what regions does upstash support",
-  "how to use upstash with vercel",
-  "how to use upstash from cloudflare workers",
-];
+import ASK_EXAMPLES from "./ask-examples.json";
 
 function askUrl(question: string): string {
   return `${SITE_URL}/ask?q=${question.replace(/ /g, "+")}`;


### PR DESCRIPTION
## Why

Agents using web search tools (tested with Exa and Parallel via OpenCode) never learned about `/ask`: those tools index the **HTML** version of pages, and after #611 the hint only lived in markdown-negotiated responses, robots.txt and the 404. `llms.txt` didn't mention it either.

## Changes

- **`public/llms.txt`** — `/ask` entry under `## AI Agents` with example queries.
- **Footer** — one visible "For AI agents" line covering `/ask` and `/start-redis` (merged with the existing start-redis note). This is the change that lands in crawler excerpts.
- **`next-sitemap.config.js`** — `additionalPaths` emits the example `/ask?q=…` URLs. Also adds `/ask` + `/ask?*` to `robotsTxtOptions.allow`: `next-sitemap` regenerates `robots.txt` on every deploy, so the hand-edit from #611 needs to live in the config too.
- **`next.config.js`** — global `Link` header gains `<…/ask?q=your+question>; rel="search"; type="application/json"`. Low expected impact, standard relation, ~100 bytes per response.
- **`src/lib/ask-examples.json`** — shared example list for `ask.ts` (TS) and the sitemap config (CJS).

## Verified

- `tsc --noEmit` clean, prettier clean
- Ran `next-sitemap` against the local build: 8 `/ask` entries in `sitemap-0.xml`, `Allow: /ask` rules present in generated `robots.txt`