### PR TITLE
ask: answer any upstash.com/ask/<slug> path

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -39,11 +39,11 @@ module.exports = {
 
     return { loc: path, changefreq: config.changefreq, priority: config.priority, lastmod: new Date().toISOString() };
   },
-  // Example /ask queries so crawlers and agents discover the answer index.
+  // Example /?q= queries so crawlers and agents discover the answer index.
   // Kept in sync with the markdown/404 hints via src/lib/ask-examples.json.
   additionalPaths: async () =>
     ASK_EXAMPLES.map((question) => ({
-      loc: `/ask?q=${question.replace(/ /g, "+")}`,
+      loc: `${SITE_URL}?q=${question.replace(/ /g, "+")}`,
       changefreq: "weekly",
       priority: 0.5,
     })),
@@ -53,7 +53,7 @@ module.exports = {
       { userAgent: "Twitterbot", allow: "/" },
       {
         userAgent: "*",
-        allow: ["/", "/ask", "/ask?*"],
+        allow: ["/", "/?q=*"],
         disallow: [
           "/*?",
           "/*%",

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -39,11 +39,15 @@ module.exports = {
 
     return { loc: path, changefreq: config.changefreq, priority: config.priority, lastmod: new Date().toISOString() };
   },
-  // Example /?q= queries so crawlers and agents discover the answer index.
+  // Example /ask/<slug> queries so crawlers and agents discover the answer index.
   // Kept in sync with the markdown/404 hints via src/lib/ask-examples.json.
+  // Slug format mirrors questionToSlug() in src/lib/ask.ts.
   additionalPaths: async () =>
     ASK_EXAMPLES.map((question) => ({
-      loc: `${SITE_URL}?q=${question.replace(/ /g, "+")}`,
+      loc: `/ask/${question
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "")}`,
       changefreq: "weekly",
       priority: 0.5,
     })),
@@ -53,7 +57,7 @@ module.exports = {
       { userAgent: "Twitterbot", allow: "/" },
       {
         userAgent: "*",
-        allow: ["/", "/?q=*"],
+        allow: ["/", "/ask/"],
         disallow: [
           "/*?",
           "/*%",

--- a/next.config.js
+++ b/next.config.js
@@ -74,14 +74,14 @@ const nextConfig = {
         ],
       },
       {
-        // Advertise the LLM-friendly index and the /ask answer index on every page
+        // Advertise the LLM-friendly index and the /?q= answer index on every page
         source: "/(.*)",
         headers: [
           {
             key: "Link",
             value: [
               '<https://upstash.com/llms.txt>; rel="alternate"; type="text/plain"; title="LLM-friendly content index"',
-              '<https://upstash.com/ask?q=your+question>; rel="search"; type="application/json"; title="Upstash answer index"',
+              '<https://upstash.com?q=your+question>; rel="search"; type="application/json"; title="Upstash answer index"',
             ].join(", "),
           },
         ],

--- a/next.config.js
+++ b/next.config.js
@@ -74,14 +74,14 @@ const nextConfig = {
         ],
       },
       {
-        // Advertise the LLM-friendly index and the /?q= answer index on every page
+        // Advertise the LLM-friendly index and the /ask answer index on every page
         source: "/(.*)",
         headers: [
           {
             key: "Link",
             value: [
               '<https://upstash.com/llms.txt>; rel="alternate"; type="text/plain"; title="LLM-friendly content index"',
-              '<https://upstash.com?q=your+question>; rel="search"; type="application/json"; title="Upstash answer index"',
+              '<https://upstash.com/ask/your-question>; rel="search"; type="application/json"; title="Upstash answer index"',
             ].join(", "),
           },
         ],

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -4,7 +4,7 @@
 
 ## AI Agents
 
-- Ask any question about Upstash: https://upstash.com/ask?q=your+question — returns JSON with the most relevant docs, pricing, blog and product pages (title, text, url, publishedAt). Examples: https://upstash.com/ask?q=how+is+redis+priced, https://upstash.com/ask?q=compare+upstash+redis+to+elasticache, https://upstash.com/ask?q=does+upstash+support+hipaa
+- Ask any question about Upstash: https://upstash.com?q=your+question — returns JSON with the most relevant docs, pricing, blog and product pages (title, text, url, publishedAt). Examples: https://upstash.com?q=how+is+redis+priced, https://upstash.com?q=compare+upstash+redis+to+elasticache, https://upstash.com?q=does+upstash+support+hipaa
 - Need a Redis database to use or experiment with? Send a `POST` request to https://upstash.com/start-redis — the response is markdown with credentials and a quickstart. Free, no signup, temporary database (expires in 3 days unless claimed).
 
 ## Pricing & Limits

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -4,7 +4,7 @@
 
 ## AI Agents
 
-- Ask any question about Upstash: https://upstash.com?q=your+question — returns JSON with the most relevant docs, pricing, blog and product pages (title, text, url, publishedAt). Examples: https://upstash.com?q=how+is+redis+priced, https://upstash.com?q=compare+upstash+redis+to+elasticache, https://upstash.com?q=does+upstash+support+hipaa
+- Ask any question about Upstash: https://upstash.com/ask/your-question (any words, hyphen-separated) — returns JSON with the most relevant docs, pricing, blog and product pages (title, text, url, publishedAt). Examples: https://upstash.com/ask/how-is-redis-priced, https://upstash.com/ask/compare-upstash-redis-to-elasticache, https://upstash.com/ask/does-upstash-support-hipaa
 - Need a Redis database to use or experiment with? Send a `POST` request to https://upstash.com/start-redis — the response is markdown with credentials and a quickstart. Free, no signup, temporary database (expires in 3 days unless claimed).
 
 ## Pricing & Limits

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -5,8 +5,7 @@ Allow: /
 # *
 User-agent: *
 Allow: /
-Allow: /ask
-Allow: /ask?*
+Allow: /?q=*
 Disallow: /*?
 Disallow: /*%
 Disallow: /v1*

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -5,7 +5,7 @@ Allow: /
 # *
 User-agent: *
 Allow: /
-Allow: /?q=*
+Allow: /ask/
 Disallow: /*?
 Disallow: /*%
 Disallow: /v1*

--- a/src/app/api/ask/[[...slug]]/route.ts
+++ b/src/app/api/ask/[[...slug]]/route.ts
@@ -1,7 +1,8 @@
 import { Search } from "@upstash/search";
+import { slugToQuestion } from "@/lib/ask";
 import { SITE_URL } from "@/utils/const";
 import { NextResponse, type NextRequest } from "next/server";
-import { logQuestion } from "./log";
+import { logQuestion } from "../log";
 
 const INDEX_NAME = "upstash-site";
 const DEFAULT_LIMIT = 5;
@@ -27,11 +28,18 @@ type Metadata = {
 
 export const dynamic = "force-dynamic";
 
-export async function GET(req: NextRequest) {
-  const q = req.nextUrl.searchParams.get("q")?.trim();
+type Context = { params: Promise<{ slug?: string[] }> };
+
+export async function GET(req: NextRequest, { params }: Context) {
+  // /ask/does-upstash-redis-have-a-rust-sdk -> "does upstash redis have a rust sdk"
+  // (proxy rewrites /ask/<slug> here). `?q=` is kept as a fallback.
+  const { slug } = await params;
+  const q =
+    (slug?.length ? slugToQuestion(slug.join("/")) : "") ||
+    req.nextUrl.searchParams.get("q")?.trim();
   if (!q) {
     return NextResponse.json(
-      { error: "missing q", usage: `${SITE_URL}?q=how+is+qstash+priced` },
+      { error: "missing q", usage: `${SITE_URL}/ask/how-is-qstash-priced` },
       { status: 400 },
     );
   }

--- a/src/app/api/ask/log.ts
+++ b/src/app/api/ask/log.ts
@@ -15,7 +15,7 @@ export function logQuestion(q: string) {
   if (!redis) return;
   waitUntil(
     redis.zincrby(KEY, 1, normalizeQuestion(q)).catch((error) => {
-      console.error("Failed to log /ask question:", error);
+      console.error("Failed to log ask question:", error);
     }),
   );
 }

--- a/src/app/api/ask/route.ts
+++ b/src/app/api/ask/route.ts
@@ -1,4 +1,5 @@
 import { Search } from "@upstash/search";
+import { SITE_URL } from "@/utils/const";
 import { NextResponse, type NextRequest } from "next/server";
 import { logQuestion } from "./log";
 
@@ -30,7 +31,7 @@ export async function GET(req: NextRequest) {
   const q = req.nextUrl.searchParams.get("q")?.trim();
   if (!q) {
     return NextResponse.json(
-      { error: "missing q", usage: "/ask?q=how+is+qstash+priced" },
+      { error: "missing q", usage: `${SITE_URL}?q=how+is+qstash+priced` },
       { status: 400 },
     );
   }
@@ -76,7 +77,7 @@ export async function GET(req: NextRequest) {
       })),
     });
   } catch (error) {
-    console.error("/ask search failed:", error);
+    console.error("ask search failed:", error);
     return NextResponse.json({ error: "search failed" }, { status: 502 });
   }
 }

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -42,8 +42,8 @@ export default async function NotFound() {
         <p className="mt-16 text-balance opacity-60">
           Looking for something specific? Just use our answer index, for example:
         </p>
-        <a href="https://upstash.com?q=compare+upstash+redis+to+elasticache" className="mt-4 text-balance opacity-100 underline">
-          https://upstash.com?q=compare+upstash+redis+to+elasticache
+        <a href="https://upstash.com/ask/compare-upstash-redis-to-elasticache" className="mt-4 text-balance opacity-100 underline">
+          https://upstash.com/ask/compare-upstash-redis-to-elasticache
         </a>
         {/* <a
           href={ASK_EXAMPLE}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -42,8 +42,8 @@ export default async function NotFound() {
         <p className="mt-16 text-balance opacity-60">
           Looking for something specific? Just use our answer index, for example:
         </p>
-        <a href="https://upstash.com/ask?q=compare+upstash+redis+to+elasticache" className="mt-4 text-balance opacity-100 underline">
-          https://upstash.com/ask?q=compare+upstash+redis+to+elasticache
+        <a href="https://upstash.com?q=compare+upstash+redis+to+elasticache" className="mt-4 text-balance opacity-100 underline">
+          https://upstash.com?q=compare+upstash+redis+to+elasticache
         </a>
         {/* <a
           href={ASK_EXAMPLE}

--- a/src/components/master/footer.tsx
+++ b/src/components/master/footer.tsx
@@ -83,10 +83,10 @@ export default function Footer({ className, ...props }: IAppFooter) {
             <p>
               For AI agents: ask any question about Upstash at{" "}
               <a
-                href="https://upstash.com/ask?q=compare+upstash+redis+to+elasticache"
+                href="https://upstash.com?q=compare+upstash+redis+to+elasticache"
                 className="underline hover:text-primary"
               >
-                https://upstash.com/ask?q=your+question
+                https://upstash.com?q=your+question
               </a>{" "}
               - returns JSON with the most relevant pages, pricing, blog and
               product pages to get your answer faster. A free Redis database is available via POST{" "}

--- a/src/components/master/footer.tsx
+++ b/src/components/master/footer.tsx
@@ -83,10 +83,10 @@ export default function Footer({ className, ...props }: IAppFooter) {
             <p>
               For AI agents: ask any question about Upstash at{" "}
               <a
-                href="https://upstash.com?q=compare+upstash+redis+to+elasticache"
+                href="https://upstash.com/ask/compare-upstash-redis-to-elasticache"
                 className="underline hover:text-primary"
               >
-                https://upstash.com?q=your+question
+                https://upstash.com/ask/your-question
               </a>{" "}
               - returns JSON with the most relevant pages, pricing, blog and
               product pages to get your answer faster. A free Redis database is available via POST{" "}

--- a/src/lib/ask.ts
+++ b/src/lib/ask.ts
@@ -1,12 +1,31 @@
 import { SITE_URL } from "@/utils/const";
 import ASK_EXAMPLES from "./ask-examples.json";
 
-function askUrl(question: string): string {
-  return `${SITE_URL}?q=${question.replace(/ /g, "+")}`;
+/** "How is Redis priced?" -> "how-is-redis-priced" */
+export function questionToSlug(question: string): string {
+  return question
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/** "does-upstash-redis-have-a-rust-sdk" -> "does upstash redis have a rust sdk" */
+export function slugToQuestion(slug: string): string {
+  let decoded = slug;
+  try {
+    decoded = decodeURIComponent(slug);
+  } catch {
+    // malformed escape sequence: fall back to the raw slug
+  }
+  return decoded.replace(/[-_+/\s]+/g, " ").trim();
+}
+
+export function askUrl(question: string): string {
+  return `${SITE_URL}/ask/${questionToSlug(question)}`;
 }
 
 export const ASK_MARKDOWN_LINE = [
-  `> **Ask:** Use ${SITE_URL}?q=your+question to search the Upstash answer index (docs, pricing, blog, product pages). Returns relevant pages with title, text, url, and publishedAt.`,
+  `> **Ask:** Use ${SITE_URL}/ask/your-question (any words, hyphen-separated) to search the Upstash answer index (docs, pricing, blog, product pages). Returns relevant pages with title, text, url, and publishedAt.`,
   `>`,
   `> Examples:`,
   ...ASK_EXAMPLES.map((question) => `> ${askUrl(question)}`),

--- a/src/lib/ask.ts
+++ b/src/lib/ask.ts
@@ -2,11 +2,11 @@ import { SITE_URL } from "@/utils/const";
 import ASK_EXAMPLES from "./ask-examples.json";
 
 function askUrl(question: string): string {
-  return `${SITE_URL}/ask?q=${question.replace(/ /g, "+")}`;
+  return `${SITE_URL}?q=${question.replace(/ /g, "+")}`;
 }
 
 export const ASK_MARKDOWN_LINE = [
-  `> **Ask:** Use ${SITE_URL}/ask?q=your+question to search the Upstash answer index (docs, pricing, blog, product pages). Returns relevant pages with title, text, url, and publishedAt.`,
+  `> **Ask:** Use ${SITE_URL}?q=your+question to search the Upstash answer index (docs, pricing, blog, product pages). Returns relevant pages with title, text, url, and publishedAt.`,
   `>`,
   `> Examples:`,
   ...ASK_EXAMPLES.map((question) => `> ${askUrl(question)}`),

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -16,6 +16,8 @@ function isBlogPath(pathname: string): boolean {
 
 const BLOG_MD_POST = /^\/blog\/([^/]+)\.md$/;
 
+const ASK_PATH = /^\/ask(?:\/(.*))?$/;
+
 const AI_BOT_REGEX =
   /GPTBot|OAI-SearchBot|ChatGPT-User|ClaudeBot|Claude-User|Claude-SearchBot|claude-code|PerplexityBot|Perplexity-User|Google-Extended|GoogleOther|Google-CloudVertexBot|Google-NotebookLM|Amazonbot|CCBot|Applebot|Applebot-Extended|meta-externalagent|Meta-ExternalAgent|DuckAssistBot|MistralAI-User|Bytespider|cohere-ai|Diffbot|AI2Bot/i;
 
@@ -79,6 +81,28 @@ export function proxy(request: NextRequest, event: NextFetchEvent) {
 
   const pathname = request.nextUrl.pathname;
 
+  const userAgent = request.headers.get("user-agent") ?? "";
+  const aiAgentMatch = userAgent.match(AI_BOT_REGEX);
+  const aiAgent = aiAgentMatch ? aiAgentMatch[0] : null;
+
+  // Answer index: upstash.com/ask/<any-slug> answers the slug as a question
+  // ("/ask/does-upstash-redis-have-a-rust-sdk"). The whole remainder of the
+  // path is the question, so URL-encoded spaces work too - which is why this
+  // runs before the whitespace junk-strip below. Rewritten to the
+  // /api/ask/[[...slug]] handler; the slug travels as a path param because a
+  // route handler still sees the *original* URL/query after a rewrite.
+  // `limit` (and a legacy `q`) pass through untouched on the query string.
+  const askMatch = pathname.match(ASK_PATH);
+  if (askMatch) {
+    const slug = askMatch[1] ? `/${askMatch[1]}` : "";
+    const res = NextResponse.rewrite(
+      new URL(`/api/ask${slug}${request.nextUrl.search}`, request.url),
+    );
+    res.headers.set("x-content-bucket", "ask");
+    if (aiAgent) res.headers.set("x-ai-agent", aiAgent);
+    return res;
+  }
+
   // Linkifiers in chat apps fuse our URLs with trailing prose ("see <url> for
   // details"), producing 404 paths like "/docs/.../max_requests_limit for
   // details". No real URL on this site contains whitespace, so strip at the
@@ -88,22 +112,6 @@ export function proxy(request: NextRequest, event: NextFetchEvent) {
     const cleanUrl = request.nextUrl.clone();
     cleanUrl.pathname = pathname.slice(0, junkIndex);
     return NextResponse.redirect(cleanUrl, 301);
-  }
-
-  const userAgent = request.headers.get("user-agent") ?? "";
-  const aiAgentMatch = userAgent.match(AI_BOT_REGEX);
-  const aiAgent = aiAgentMatch ? aiAgentMatch[0] : null;
-
-  // Answer index: upstash.com?q=your+question is served by the /api/ask
-  // handler. Only a non-empty `q` on the root path triggers it; everything
-  // else on "/" is the regular homepage.
-  if (pathname === "/" && request.nextUrl.searchParams.get("q")?.trim()) {
-    const res = NextResponse.rewrite(
-      new URL(`/api/ask${request.nextUrl.search}`, request.url),
-    );
-    res.headers.set("x-content-bucket", "ask");
-    if (aiAgent) res.headers.set("x-ai-agent", aiAgent);
-    return res;
   }
 
   // Explicit `.md` URLs (e.g. /blog.md, /blog/foo.md) always serve Markdown,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -94,6 +94,18 @@ export function proxy(request: NextRequest, event: NextFetchEvent) {
   const aiAgentMatch = userAgent.match(AI_BOT_REGEX);
   const aiAgent = aiAgentMatch ? aiAgentMatch[0] : null;
 
+  // Answer index: upstash.com?q=your+question is served by the /api/ask
+  // handler. Only a non-empty `q` on the root path triggers it; everything
+  // else on "/" is the regular homepage.
+  if (pathname === "/" && request.nextUrl.searchParams.get("q")?.trim()) {
+    const res = NextResponse.rewrite(
+      new URL(`/api/ask${request.nextUrl.search}`, request.url),
+    );
+    res.headers.set("x-content-bucket", "ask");
+    if (aiAgent) res.headers.set("x-ai-agent", aiAgent);
+    return res;
+  }
+
   // Explicit `.md` URLs (e.g. /blog.md, /blog/foo.md) always serve Markdown,
   // regardless of Accept header. This is the conventional pattern (GitHub,
   // llms.txt, etc.) and gives us distinct cache keys without Vary headaches.


### PR DESCRIPTION
## Summary
- `/ask?q=` was not working out, so the answer index is now **path-based**: **`https://upstash.com/ask/does-upstash-redis-have-a-rust-sdk`** answers the slug as the question. Any slug works — `-`, `_`, `+`, `/` and URL-encoded spaces all become spaces.
- `src/proxy.ts` matches `/ask` and `/ask/<anything>` and rewrites to the handler at `src/app/api/ask/[[...slug]]/route.ts` (under `/api`, so proxy/tracker-excluded and robots-disallowed like `/api/blog/markdown`). Sets `x-content-bucket: ask` and `x-ai-agent` like the other rewrites. The ask block runs before the whitespace junk-strip so encoded spaces in a question survive.
- **Why a path param and not `?q=` on the rewrite:** in Next 16 a route handler still sees the *original* request URL/query after a proxy rewrite (only routing uses the rewritten path), so a `q` added during the rewrite never arrived. Route params do come from the rewritten path — same mechanism the blog markdown rewrites rely on.
- Handler: question = slug param, falling back to `?q=` (kept for compatibility); `limit` passes through unchanged. `/ask` with no question returns the 400 usage JSON.
- `slugToQuestion` / `questionToSlug` live in `src/lib/ask.ts`. All advertised URLs repointed to `/ask/<slug>`: `llms.txt`, sitemap + `next-sitemap.config.js`, robots `Allow: /ask/`, `Link: rel="search"` header, footer, 404 page/markdown, pricing/blog markdown hints.

## Test plan
Verified against a local dev server:
- [x] `/ask/does-upstash-redis-have-a-rust-sdk` → 200 JSON, `question: "does upstash redis have a rust sdk"`, `x-content-bucket: ask`
- [x] `/ask/how-is-redis-priced?limit=1` → 1 result (limit passes through)
- [x] `/ask/does%20upstash%20support%20hipaa` and `/ask/multi/segment/question` → parsed to space-separated questions
- [x] With `User-Agent: ClaudeBot` → `x-ai-agent: ClaudeBot`
- [x] `/ask?q=how+is+redis+priced` → still 200 (fallback)
- [x] `/ask` → 400 `{"error":"missing q","usage":"https://upstash.com/ask/how-is-qstash-priced"}`
- [x] `/`, `/?q=x` → homepage; `/askfoo` → 404 (regex is anchored)
- [x] `tsc --noEmit` clean; `next-sitemap.config.js` emits `/ask/how-is-redis-priced` etc.
