### PR TITLE
fix: dark-mode plan select and cookie banner vs Intercom launcher on …

### DIFF
--- a/src/components/notice-banner.tsx
+++ b/src/components/notice-banner.tsx
@@ -79,11 +79,15 @@ export const NoticeBanner = () => {
     <div
       className={cx(
         "fixed inset-x-0 bottom-0 z-50 flex w-full items-center justify-between gap-2",
-        "bg-emerald-400 px-4 py-2.5 text-[13px] text-zinc-950 shadow-lg",
+        "bg-emerald-400 py-2.5 pl-4 text-[13px] text-zinc-950 shadow-lg",
+        // On mobile the banner spans the full width, so the Intercom launcher
+        // (48px, 20px in from the bottom-right corner) sits on top of it.
+        // Reserve that corner so the Accept button is never covered.
+        "pr-20",
         // mx-auto rather than left-1/2, so shrink-to-fit gets the whole viewport
         // to measure against and the text stays on one line
         "md:bottom-4 md:mx-auto md:w-fit md:max-w-[min(94vw,880px)]",
-        "md:rounded-3xl md:py-1.5 md:pl-4 md:pr-1.5",
+        "md:rounded-3xl md:py-1.5 md:pr-1.5",
       )}
     >
       <p className="leading-snug">

--- a/src/components/pricing/blob/compare-table.tsx
+++ b/src/components/pricing/blob/compare-table.tsx
@@ -263,7 +263,7 @@ function MobileSelectCol({
 }: React.ComponentProps<"select">) {
   return (
     <select
-      className="mb-2 bg-white px-4 py-2 font-semibold md:hidden"
+      className="mb-2 bg-white px-4 py-2 font-semibold md:hidden dark:bg-bg-mute"
       onChange={(event) => {
         trackEvent("pricing_compare_select", {
           product: "blob",

--- a/src/components/pricing/box/compare-table.tsx
+++ b/src/components/pricing/box/compare-table.tsx
@@ -482,7 +482,7 @@ export default function CompareTable() {
 function MobilePlanSelect({ ...props }: React.ComponentProps<"select">) {
   return (
     <select
-      className="mb-2 bg-white px-4 py-2 font-semibold md:hidden"
+      className="mb-2 bg-white px-4 py-2 font-semibold md:hidden dark:bg-bg-mute"
       {...props}
     >
       <option value={BoxPlan.Free}>Free</option>

--- a/src/components/pricing/qstash/compare-table.tsx
+++ b/src/components/pricing/qstash/compare-table.tsx
@@ -986,7 +986,7 @@ function MobileSelectCol({
 }: React.ComponentProps<"select">) {
   return (
     <select
-      className="mb-2 bg-white px-4 py-2 font-semibold md:hidden"
+      className="mb-2 bg-white px-4 py-2 font-semibold md:hidden dark:bg-bg-mute"
       onChange={(event) => {
         trackEvent("pricing_compare_select", {
           product: "qstash",

--- a/src/components/pricing/search/compare-table.tsx
+++ b/src/components/pricing/search/compare-table.tsx
@@ -498,7 +498,7 @@ function MobileSelectCol({
 }: React.ComponentProps<"select">) {
   return (
     <select
-      className="mb-2 bg-white px-4 py-2 font-semibold md:hidden"
+      className="mb-2 bg-white px-4 py-2 font-semibold md:hidden dark:bg-bg-mute"
       onChange={(event) => {
         trackEvent("pricing_compare_select", {
           product: "search",

--- a/src/components/pricing/vector/compare-table.tsx
+++ b/src/components/pricing/vector/compare-table.tsx
@@ -760,7 +760,7 @@ function MobileSelectCol({
 }: React.ComponentProps<"select">) {
   return (
     <select
-      className="mb-2 bg-white px-4 py-2 font-semibold md:hidden"
+      className="mb-2 bg-white px-4 py-2 font-semibold md:hidden dark:bg-bg-mute"
       onChange={(event) => {
         trackEvent("pricing_compare_select", {
           product: "vector",

--- a/src/components/pricing/workflow/compare-table.tsx
+++ b/src/components/pricing/workflow/compare-table.tsx
@@ -537,7 +537,7 @@ function MobileSelectCol({
 }: React.ComponentProps<"select">) {
   return (
     <select
-      className="mb-2 bg-white px-4 py-2 font-semibold md:hidden"
+      className="mb-2 bg-white px-4 py-2 font-semibold md:hidden dark:bg-bg-mute"
       onChange={(event) => {
         trackEvent("pricing_compare_select", {
           product: "workflow",


### PR DESCRIPTION
…mobile

The mobile plan `<select>` on the compare tables kept a white background in dark mode while inheriting the light text color, so the selected plan was unreadable. Redis already used `dark:bg-bg-mute`; apply it to the Blob, Box, QStash, Search, Vector and Workflow tables too.

On mobile the cookie/terms banner spans the full width, so the Intercom launcher sat on top of the Accept button. Reserve the bottom-right corner with `pr-20` below `md` so the actions clear the launcher.

Claude-Session: https://claude.ai/code/session_01FmBBVtJmatb1BXmGN3nncc