### PR TITLE
DX-3014: clarify Blob free plan pricing limits

### DIFF
--- a/data/blog/2023-09-06-nextjs-replicate.mdx
+++ b/data/blog/2023-09-06-nextjs-replicate.mdx
@@ -6,7 +6,7 @@ authors:
 tags: [ai, serverless, redis, replicate]
 ---
 
-In this article, we will show you how to rate limit a Next.js app using Upstash Redis. We will be rebuilding [lofianime.com](https://www.lofianime.com/), an app that generates AI images with a Stable Diffusion model on Replicate. We will focus predominantly on how to implement Upstash rate limiting with a Redis database. You can check out the original source code for this project on [GitHub](https://github.com/alpinecodex/lofianime).
+In this article, we will show you how to rate limit a Next.js app using Upstash Redis. We will be rebuilding LofiAnime, an app that generates AI images with a Stable Diffusion model on Replicate. We will focus predominantly on how to implement Upstash rate limiting with a Redis database. You can check out the original source code for this project on [GitHub](https://github.com/alpinecodex/lofianime).
 
 ## Why use Upstash?
 
@@ -255,5 +255,4 @@ export async function GET(request) {
 ## About the Author
 
 [Cameron Youngblood](https://twitter.com/youngbloodcyb) is a Full Stack Developer at [Ampry Software](https://www.ampry.com/) and a contributor to [Alpine Codex](https://www.alpinecodex.com/).
-[lofianime.com](https://www.lofianime.com/)
 Star this project on [GitHub](https://github.com/alpinecodex/lofianime)

--- a/data/blog/2025-02-24-workflow-invoke-logs.mdx
+++ b/data/blog/2025-02-24-workflow-invoke-logs.mdx
@@ -159,7 +159,7 @@ export const { POST } = serve(
 )
 ```
 
-Check out the [documentation](https://upstash.com/docs/workflow/howto/flow-control) for more details.
+Check out the [documentation](https://upstash.com/docs/workflow/features/flow-control) for more details.
 
 ## Development Server
 

--- a/src/components/pricing/blob/pricing-table.tsx
+++ b/src/components/pricing/blob/pricing-table.tsx
@@ -41,8 +41,7 @@ export default function PricingTable() {
           </div>
         </div>
 
-        {/* Included per month. Same four meters as the payg card below, so the
-            two read as a cap against a rate rather than as different lists. */}
+        {/* Free plan limits for the same meters as the payg card below. */}
         <div className="w-full px-6 *:border-b *:border-bg-mute">
           {BLOB_CARD_METERS.map((meter) => (
             <div key={meter.key} className="py-3">
@@ -103,6 +102,12 @@ export default function PricingTable() {
           </Button>
         </div>
       </div>
+
+      <p className="text-center text-sm text-text-mute md:col-span-2">
+        If you exceed the free plan limits, requests stop until the 30-day
+        window resets. Upgrade to Pay as You Go to continue, with all usage
+        billed from the first unit.
+      </p>
     </div>
   );
 }

--- a/src/components/pricing/blob/pricing-table.tsx
+++ b/src/components/pricing/blob/pricing-table.tsx
@@ -36,7 +36,7 @@ export default function PricingTable() {
         </div>
 
         <div className="grow">
-          <div className="text-balance rounded-lg bg-bg-mute px-3 py-2 text-sm text-primary-text dark:text-text-mute">
+          <div className="max-w-[30ch] text-balance rounded-lg bg-bg-mute px-3 py-2 text-sm text-primary-text dark:text-text-mute">
             {BLOB_FREE_PLAN.description}
           </div>
         </div>
@@ -80,7 +80,7 @@ export default function PricingTable() {
         </div>
 
         <div className="grow">
-          <div className="text-balance rounded-lg bg-bg-mute px-3 py-2 text-sm text-primary-text dark:text-text-mute">
+          <div className="max-w-[30ch] text-balance rounded-lg bg-bg-mute px-3 py-2 text-sm text-primary-text dark:text-text-mute">
             {BLOB_PAYG_PLAN.description}
           </div>
         </div>

--- a/src/components/pricing/blob/pricing-table.tsx
+++ b/src/components/pricing/blob/pricing-table.tsx
@@ -41,7 +41,8 @@ export default function PricingTable() {
           </div>
         </div>
 
-        {/* Free plan limits for the same meters as the payg card below. */}
+        {/* Included per month. Same four meters as the payg card below, so the
+            two read as a cap against a rate rather than as different lists. */}
         <div className="w-full px-6 *:border-b *:border-bg-mute">
           {BLOB_CARD_METERS.map((meter) => (
             <div key={meter.key} className="py-3">
@@ -102,12 +103,6 @@ export default function PricingTable() {
           </Button>
         </div>
       </div>
-
-      <p className="text-center text-sm text-text-mute md:col-span-2">
-        If you exceed the free plan limits, requests stop until the 30-day
-        window resets. Upgrade to Pay as You Go to continue, with all usage
-        billed from the first unit.
-      </p>
     </div>
   );
 }

--- a/src/data/pricing/blob.ts
+++ b/src/data/pricing/blob.ts
@@ -96,7 +96,7 @@ export const BLOB_METERS: BlobMeter[] = [
   },
   {
     key: "bandwidth",
-    label: "Bandwidth",
+    label: "Bandwidth (Egress)",
     freeIncluded: "10 GB / month",
     rate: `$${BLOB_RATES.bandwidthPerGb.toFixed(2)} per GB`,
     tooltip:

--- a/src/data/pricing/blob.ts
+++ b/src/data/pricing/blob.ts
@@ -70,7 +70,7 @@ export const BLOB_METERS: BlobMeter[] = [
   {
     key: "storage",
     label: "Storage",
-    freeIncluded: "1 GB / month",
+    freeIncluded: "1 GB",
     rate: `$${BLOB_RATES.storagePerGb.toFixed(2)} per GB`,
     tooltip:
       "Measured on the monthly average of your bucket size, not its peak.",
@@ -79,7 +79,7 @@ export const BLOB_METERS: BlobMeter[] = [
   {
     key: "simple-ops",
     label: "Simple Operations",
-    freeIncluded: "First 10,000",
+    freeIncluded: "10,000 / month",
     rate: `$${BLOB_RATES.simpleOpsPerMillion.toFixed(2)} per 1M`,
     tooltip:
       "Reads: downloads, HEAD requests and bucket-level GETs. Same rate from origin or CDN.",
@@ -88,7 +88,7 @@ export const BLOB_METERS: BlobMeter[] = [
   {
     key: "advanced-ops",
     label: "Advanced Operations",
-    freeIncluded: "First 2,000",
+    freeIncluded: "2,000 / month",
     rate: `$${BLOB_RATES.advancedOpsPerMillion.toFixed(2)} per 1M`,
     tooltip:
       "Uploads, copies, renames, listings and each multipart part. Deletes are free.",
@@ -97,7 +97,7 @@ export const BLOB_METERS: BlobMeter[] = [
   {
     key: "bandwidth",
     label: "Bandwidth",
-    freeIncluded: "First 10 GB",
+    freeIncluded: "10 GB / month",
     rate: `$${BLOB_RATES.bandwidthPerGb.toFixed(2)} per GB`,
     tooltip:
       "Bytes served out of the bucket. Uploads are free; you pay only for what leaves.",


### PR DESCRIPTION
Blob pricing now shows free storage as “1 GB” and bandwidth as “10 GB / month,” replacing the ambiguous “First 10 GB.” Operation allowances also show explicit monthly limits. The traffic meter is labeled “Bandwidth (Egress)” to clarify that it measures outbound traffic. The shared data updates the plan cards, comparison table, and Markdown pricing endpoint.

Both plan descriptions use the same maximum width so they wrap onto two balanced lines on desktop and mobile.

Also repairs two older blog posts that blocked the repository-wide link checker: updates the moved Workflow flow-control documentation URL and removes unavailable LofiAnime demo links while preserving its source-repository links.

Fixes [DX-3014](https://linear.app/upstash/issue/DX-3014).

Validation: Biome and Prettier passed, including after the final label change. Checked description wrapping in Chromium at desktop and mobile widths and verified the free-plan values in the Markdown endpoint.

The repository-wide Link Checker passes on GitHub after the blog link repairs.
